### PR TITLE
89: Validate number_of_rays is greater than zero

### DIFF
--- a/wolf/wolf_common/wolf_scene.cpp
+++ b/wolf/wolf_common/wolf_scene.cpp
@@ -3,6 +3,7 @@
 #include <glm/glm.hpp>
 
 #include <cmath>
+#include <stdexcept>
 
 namespace wolf {
 WolfScene::WolfScene(std::unique_ptr<const RawMap> raw_map,
@@ -13,6 +14,10 @@ WolfScene::WolfScene(std::unique_ptr<const RawMap> raw_map,
     , last_timestamp_ms_{timestamp()}
     , walls_(number_of_rays)
     , ray_rots_(number_of_rays) {
+  if (number_of_rays == 0u) {
+    throw std::invalid_argument("number_of_rays must be greater than 0");
+  }
+
   const auto fov_in_rad = glm::radians(static_cast<float>(fov_in_degrees));
 
   const auto fov_step = fov_in_rad / (ray_rots_.size() - 1u);


### PR DESCRIPTION
Add early validation in `WolfScene` constructor to prevent division by zero when `number_of_rays` is 0 (a user-supplied command-line parameter).

Closes #89