### PR TITLE
92: Add bounds check in NeuralNetwork::set_input()

### DIFF
--- a/ai/ai_common/neural_network.cpp
+++ b/ai/ai_common/neural_network.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <random>
+#include <stdexcept>
 
 namespace ai {
 namespace {
@@ -42,7 +43,12 @@ void NeuralNetwork::init_random(const float mid, const float spread) {
   }
 }
 
-void NeuralNetwork::set_input(const std::size_t index, const float value) { inputs_[index] = value; }
+void NeuralNetwork::set_input(const std::size_t index, const float value) {
+  if (index >= inputs_.size()) {
+    throw std::out_of_range("NeuralNetwork::set_input(): index " + std::to_string(index) + " out of range");
+  }
+  inputs_[index] = value;
+}
 
 const std::vector<float> &NeuralNetwork::get_output() const { return activations_.back(); }
 


### PR DESCRIPTION
Validate that the index is within range before accessing `inputs_`. An out-of-range index previously caused undefined behavior.

Closes #92