### PR TITLE
95: Add mutex protection to ShaderProgram uniform cache

### DIFF
--- a/gp/gl/shader_program.cpp
+++ b/gp/gl/shader_program.cpp
@@ -65,6 +65,7 @@ GLint ShaderProgram::uniform_location(const std::string &name) {
 }
 
 void ShaderProgram::check_uniform_location(const std::string &name) {
+  const auto lock = std::lock_guard(uniform_locations_mutex_);
   if (uniform_locations_.count(name) == 0) {
     uniform_locations_[name] = glGetUniformLocation(id(), name.c_str());
     if (uniform_locations_[name] == -1) {

--- a/gp/gl/shader_program.hpp
+++ b/gp/gl/shader_program.hpp
@@ -4,6 +4,7 @@
 
 #include <glm/glm.hpp>
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -109,6 +110,7 @@ private:
   void check_uniform_location(const std::string &name);
 
   GLuint id_{};
+  mutable std::mutex uniform_locations_mutex_{};
   std::unordered_map<std::string, GLint> uniform_locations_{};
 };
 } // namespace gp::gl


### PR DESCRIPTION
Protect the mutable `uniform_locations_` map with a `std::mutex` to prevent data races when `set_uniform()` is called from multiple threads.

Closes #95