### PR TITLE
96: Replace Event union with std::variant

### DIFF
--- a/gp/misc/event.cpp
+++ b/gp/misc/event.cpp
@@ -12,34 +12,32 @@ bool Event::MouseMoveData::right_is_down() const { return mouse_button_mask & Mo
 Event::Event(const Type type, const std::uint64_t timestamp)
     : type_{type}
     , timestamp_{timestamp} {
-  construct_complex_members();
+  switch (type) {
+  case Type::Init:
+    data_.emplace<InitData>();
+    break;
+  case Type::Resize:
+    data_.emplace<ResizeData>();
+    break;
+  case Type::MouseButton:
+    data_.emplace<MouseButtonData>();
+    break;
+  case Type::MouseMove:
+    data_.emplace<MouseMoveData>();
+    break;
+  case Type::MouseScroll:
+    data_.emplace<MouseScrollData>();
+    break;
+  case Type::Key:
+    data_.emplace<KeyData>();
+    break;
+  case Type::DragDrop:
+    data_.emplace<DragDropData>();
+    break;
+  default:
+    break;
+  }
 }
-
-Event::Event(const Event &other)
-    : type_{other.type()}
-    , timestamp_{other.timestamp()} {
-  copy(other);
-}
-
-Event::Event(Event &&other) noexcept
-    : type_{other.type()}
-    , timestamp_{other.timestamp()} {
-  move(std::move(other));
-}
-
-Event &Event::operator=(const Event &other) {
-  destruct_complex_members();
-  copy(other);
-  return *this;
-}
-
-Event &Event::operator=(Event &&other) noexcept {
-  destruct_complex_members();
-  move(std::move(other));
-  return *this;
-}
-
-Event::~Event() { destruct_complex_members(); }
 
 Event::Type Event::type() const { return type_; }
 
@@ -49,182 +47,97 @@ Event::InitData &Event::init() {
   if (type() != Type::Init) {
     throw std::runtime_error("Wrong data access");
   }
-  return init_;
+  return std::get<InitData>(data_);
 }
 
 const Event::InitData &Event::init() const {
   if (type() != Type::Init) {
     throw std::runtime_error("Wrong data access");
   }
-  return init_;
+  return std::get<InitData>(data_);
 }
 
 Event::ResizeData &Event::resize() {
   if (type() != Type::Resize) {
     throw std::runtime_error("Wrong data access");
   }
-  return resize_;
+  return std::get<ResizeData>(data_);
 }
 
 const Event::ResizeData &Event::resize() const {
   if (type() != Type::Resize) {
     throw std::runtime_error("Wrong data access");
   }
-  return resize_;
+  return std::get<ResizeData>(data_);
 }
 
 Event::MouseButtonData &Event::mouse_button() {
   if (type() != Type::MouseButton) {
     throw std::runtime_error("Wrong data access");
   }
-  return mouse_button_;
+  return std::get<MouseButtonData>(data_);
 }
 
 const Event::MouseButtonData &Event::mouse_button() const {
   if (type() != Type::MouseButton) {
     throw std::runtime_error("Wrong data access");
   }
-  return mouse_button_;
+  return std::get<MouseButtonData>(data_);
 }
 
 Event::MouseMoveData &Event::mouse_move() {
   if (type() != Type::MouseMove) {
     throw std::runtime_error("Wrong data access");
   }
-  return mouse_move_;
+  return std::get<MouseMoveData>(data_);
 }
 
 const Event::MouseMoveData &Event::mouse_move() const {
   if (type() != Type::MouseMove) {
     throw std::runtime_error("Wrong data access");
   }
-  return mouse_move_;
+  return std::get<MouseMoveData>(data_);
 }
 
 Event::MouseScrollData &Event::mouse_scroll() {
   if (type() != Type::MouseScroll) {
     throw std::runtime_error("Wrong data access");
   }
-  return mouse_scroll_;
+  return std::get<MouseScrollData>(data_);
 }
 
 const Event::MouseScrollData &Event::mouse_scroll() const {
   if (type() != Type::MouseScroll) {
     throw std::runtime_error("Wrong data access");
   }
-  return mouse_scroll_;
+  return std::get<MouseScrollData>(data_);
 }
 
 Event::KeyData &Event::key() {
   if (type() != Type::Key) {
     throw std::runtime_error("Wrong data access");
   }
-  return key_;
+  return std::get<KeyData>(data_);
 }
 
 const Event::KeyData &Event::key() const {
   if (type() != Type::Key) {
     throw std::runtime_error("Wrong data access");
   }
-  return key_;
+  return std::get<KeyData>(data_);
 }
 
 Event::DragDropData &Event::drag_drop() {
   if (type() != Type::DragDrop) {
     throw std::runtime_error("Wrong data access");
   }
-  return drag_drop_;
+  return std::get<DragDropData>(data_);
 }
 
 const Event::DragDropData &Event::drag_drop() const {
   if (type() != Type::DragDrop) {
     throw std::runtime_error("Wrong data access");
   }
-  return drag_drop_;
-}
-
-void Event::copy(const Event &other) {
-  assign_all(other);
-  switch (type()) {
-  case Type::DragDrop:
-    new (&drag_drop_.filepath) std::string(other.drag_drop().filepath);
-    break;
-  default:
-    break;
-  }
-}
-
-void Event::move(Event &&other) {
-  assign_all(other);
-  switch (type()) {
-  case Type::DragDrop:
-    new (&drag_drop_.filepath) std::string(std::move(other.drag_drop().filepath));
-    break;
-  default:
-    break;
-  }
-}
-
-void Event::construct_complex_members() {
-  switch (type()) {
-  case Type::DragDrop:
-    new (&drag_drop_.filepath) std::string();
-    break;
-  default:
-    break;
-  }
-}
-
-void Event::destruct_complex_members() {
-  switch (type()) {
-  case Type::DragDrop:
-    drag_drop_.filepath.~basic_string();
-    break;
-  default:
-    break;
-  }
-}
-
-void Event::assign_all(const Event &other) {
-  switch (type()) {
-  case Type::None:
-    break;
-  case Type::Init:
-    init_.width = other.init_.width;
-    init_.height = other.init_.height;
-    break;
-  case Type::Quit:
-    break;
-  case Type::Resize:
-    resize_.width = other.resize_.width;
-    resize_.height = other.resize_.height;
-    break;
-  case Type::Redraw:
-    break;
-  case Type::MouseButton:
-    mouse_button_.action = other.mouse_button_.action;
-    mouse_button_.button = other.mouse_button_.button;
-    break;
-  case Type::MouseMove:
-    mouse_move_.x = other.mouse_move_.x;
-    mouse_move_.y = other.mouse_move_.y;
-    mouse_move_.x_rel = other.mouse_move_.x_rel;
-    mouse_move_.y_rel = other.mouse_move_.y_rel;
-    mouse_move_.mouse_button_mask = other.mouse_move_.mouse_button_mask;
-    break;
-  case Type::MouseScroll:
-    mouse_scroll_.vertical = other.mouse_scroll_.vertical;
-    mouse_scroll_.horizontal = other.mouse_scroll_.horizontal;
-    break;
-  case Type::Key:
-    key_.action = other.key_.action;
-    key_.scan_code = other.key_.scan_code;
-    break;
-  case Type::DragDrop:
-    break;
-  default:
-    throw std::runtime_error("Unhandled event type occurred");
-    break;
-  }
+  return std::get<DragDropData>(data_);
 }
 } // namespace gp::misc

--- a/gp/misc/event.hpp
+++ b/gp/misc/event.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <variant>
 
 namespace gp::misc {
 /**
@@ -357,11 +358,11 @@ public:
   };
 
   Event(const Type type, const std::uint64_t timestamp);
-  Event(const Event &other);
-  Event(Event &&other) noexcept;
-  Event &operator=(const Event &other);
-  Event &operator=(Event &&other) noexcept;
-  ~Event();
+  Event(const Event &other) = default;
+  Event(Event &&other) noexcept = default;
+  Event &operator=(const Event &other) = default;
+  Event &operator=(Event &&other) noexcept = default;
+  ~Event() = default;
   Type type() const;
   std::uint64_t timestamp() const;
   InitData &init();
@@ -380,12 +381,6 @@ public:
   const DragDropData &drag_drop() const;
 
 private:
-  void copy(const Event &other);
-  void move(Event &&other);
-  void construct_complex_members();
-  void destruct_complex_members();
-  void assign_all(const Event &other);
-
   /**
    * @brief The type of user input event.
    */
@@ -397,16 +392,16 @@ private:
   std::uint64_t timestamp_{};
 
   /**
-   * @brief Union representing various input event data.
+   * @brief Variant representing various input event data.
    */
-  union {
-    InitData init_;                /**< Init event */
-    ResizeData resize_;            /**< Resize event */
-    MouseButtonData mouse_button_; /**< Mouse button event */
-    MouseMoveData mouse_move_;     /**< Mouse move event */
-    MouseScrollData mouse_scroll_; /**< Mouse scroll event */
-    KeyData key_;                  /**< Key event */
-    DragDropData drag_drop_;       /**< Drag and drop event */
-  };
+  using EventData = std::variant<std::monostate,
+                                 InitData,
+                                 ResizeData,
+                                 MouseButtonData,
+                                 MouseMoveData,
+                                 MouseScrollData,
+                                 KeyData,
+                                 DragDropData>;
+  EventData data_;
 };
 } // namespace gp::misc


### PR DESCRIPTION
Replace the C union containing `DragDropData` (with `std::string`) with a type-safe `std::variant`. This eliminates manual placement-new/destruction and makes copy/move/assignment automatically correct.

The public API remains unchanged - all existing accessor methods (`init()`, `resize()`, etc.) continue to work identically.

Closes #96