### PR TITLE
97: Add is_open() check in load_txt_file

### DIFF
--- a/gp/utils/utils.cpp
+++ b/gp/utils/utils.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <random>
 #include <sstream>
+#include <stdexcept>
 
 #ifdef __APPLE__
 # include <libgen.h>
@@ -41,6 +42,9 @@ std::string generate_random_string(const std::size_t length) {
 
 std::string load_txt_file(const std::string &filename) {
   auto txt_file = std::ifstream{filename};
+  if (!txt_file.is_open()) {
+    throw std::runtime_error("Failed to open file: " + filename);
+  }
   auto buffer = std::stringstream{};
   buffer << txt_file.rdbuf();
   return buffer.str();


### PR DESCRIPTION
Add `is_open()` check in `load_txt_file()` and throw `std::runtime_error` if the file cannot be opened, instead of silently returning an empty string.

Closes #97