### PR TITLE
98: Replace static dump with throw in BlockType::operator[]

### DIFF
--- a/wolf/wolf_common/raw_map.cpp
+++ b/wolf/wolf_common/raw_map.cpp
@@ -27,8 +27,7 @@ std::uint16_t &RawMap::BlockType::operator[](const std::size_t index) {
   if (index == 2u) {
     return reinterpret_cast<std::underlying_type<Map::Extra>::type &>(extra);
   }
-  static auto dump = std::uint16_t{};
-  return dump;
+  throw std::out_of_range("BlockType::operator[]: index out of range");
 }
 
 RawMap::RawMap(const int width, const int height, std::vector<BlockType> &&blocks)


### PR DESCRIPTION
The non-const `BlockType::operator[]` returned a reference to a static local on out-of-bounds access, silently discarding writes. Throw `std::out_of_range` instead to match the const overload's behavior of returning `0u`.

Closes #98