### PR TITLE
101: Set paired flag on request_video_stream

### DIFF
--- a/streaming/streaming_signaling_server/server.cpp
+++ b/streaming/streaming_signaling_server/server.cpp
@@ -177,6 +177,9 @@ void Server::parse_command(std::shared_ptr<Client> &client, const nlohmann::json
     const auto streamer = std::string{json_command.at("streamer")};
     const auto receiver = std::string{json_command.at("receiver")};
 
+    streamers_[streamer].paired = true;
+    receivers_[receiver].paired = true;
+
     const auto request_video_stream_json = nlohmann::json{
         {"streamer", streamer},
         {"receiver", receiver}


### PR DESCRIPTION
Set `streamer.paired` and `receiver.paired` to `true` when handling the `request_video_stream` command. Without this, already-paired streamers/receivers continued to appear in `video_stream_infos` broadcasts.

Closes #101