### PR TITLE
104: Fix resource leaks in Renderer::draw_text

### DIFF
--- a/gp/sdl/renderer.cpp
+++ b/gp/sdl/renderer.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <stdexcept>
 
 namespace gp::sdl {
@@ -139,16 +140,21 @@ void Renderer::draw_text(const std::string &text, const int x, const int y) cons
     throw std::runtime_error("Couldn't initialize TTF: " + std::string(SDL_GetError()));
   }
 
-  const auto font = TTF_OpenFont("data/Consolas.ttf", 24);
+  const auto font =
+      std::unique_ptr<TTF_Font, decltype(&TTF_CloseFont)>{TTF_OpenFont("data/Consolas.ttf", 24), TTF_CloseFont};
   if (!font) {
     throw std::runtime_error("Could not load font: " + std::string(SDL_GetError()));
   }
-  const auto surface = TTF_RenderText_Solid(font, text.c_str(), 0, color);
+  const auto surface = std::unique_ptr<SDL_Surface, decltype(&SDL_DestroySurface)>{
+      TTF_RenderText_Solid(font.get(), text.c_str(), 0, color),
+      SDL_DestroySurface};
   if (!surface) {
     throw std::runtime_error("Could not render text: " + std::string(SDL_GetError()));
   }
 
-  const auto texture = SDL_CreateTextureFromSurface(r_->r(), surface);
+  const auto texture =
+      std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)>{SDL_CreateTextureFromSurface(r_->r(), surface.get()),
+                                                                  SDL_DestroyTexture};
   if (!texture) {
     throw std::runtime_error("Could not create texture: " + std::string(SDL_GetError()));
   }
@@ -159,11 +165,7 @@ void Renderer::draw_text(const std::string &text, const int x, const int y) cons
   rect.w = static_cast<float>(surface->w);
   rect.h = static_cast<float>(surface->h);
 
-  SDL_RenderTexture(r_->r(), texture, nullptr, &rect);
-
-  TTF_CloseFont(font);
-  SDL_DestroySurface(surface);
-  SDL_DestroyTexture(texture);
+  SDL_RenderTexture(r_->r(), texture.get(), nullptr, &rect);
 
   TTF_Quit();
 }


### PR DESCRIPTION
Replace raw SDL/TTF resource handles with `unique_ptr` using custom deleters so font, surface, and texture are properly cleaned up if an exception is thrown mid-function.

Previously, if `TTF_RenderText_Solid` or `SDL_CreateTextureFromSurface` failed, the already-opened font (and possibly surface) would leak.

Closes #104