### PR TITLE
106: Move CGLTF_IMPLEMENTATION to dedicated translation unit

### DIFF
--- a/loaders/loaders_cgltf/cgltf_impl.cpp
+++ b/loaders/loaders_cgltf/cgltf_impl.cpp
@@ -1,0 +1,2 @@
+#define CGLTF_IMPLEMENTATION
+#include <cgltf.h>

--- a/loaders/loaders_cgltf/model.cpp
+++ b/loaders/loaders_cgltf/model.cpp
@@ -3,7 +3,6 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 
-#define CGLTF_IMPLEMENTATION
 #include <cgltf.h>
 
 #include <span>


### PR DESCRIPTION
Move `#define CGLTF_IMPLEMENTATION` + `#include <cgltf.h>` into a dedicated `cgltf_impl.cpp` so `model.cpp` only includes the header. This prevents ODR violations if `cgltf.h` is included from additional translation units in the future.

Closes #106