### PR TITLE
122: CMake: remove redundant C++17 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.30)
 
 project(sandbox CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 include(cmake/ResourceUtils.cmake)


### PR DESCRIPTION
Closes #122

Removes the global `CMAKE_CXX_STANDARD 17` / `CMAKE_CXX_STANDARD_REQUIRED` block from the root `CMakeLists.txt`. Every target already explicitly requests C++23 via `target_compile_features(... cxx_std_23)`, so the global setting was misleading and incorrect.