### PR TITLE
125: CMake: change FFmpeg link directories scope from PUBLIC to PRIVATE

### DIFF
--- a/gp/CMakeLists.txt
+++ b/gp/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(
 
 if(NOT EMSCRIPTEN)
   target_include_directories(gp PUBLIC ${FFMPEG_INCLUDE_DIRS})
-  target_link_directories(gp PUBLIC ${FFMPEG_LIBRARY_DIRS})
+  target_link_directories(gp PRIVATE ${FFMPEG_LIBRARY_DIRS})
   target_link_libraries(gp PUBLIC ${FFMPEG_LIBRARIES})
   target_link_libraries(gp PUBLIC glad::glad)
 endif()


### PR DESCRIPTION
Closes #125

`target_link_directories(gp PUBLIC ...)` propagated the FFmpeg library search path to every downstream target that linked `gp`, polluting their linker environment. Changed to `PRIVATE` since consumers of `gp` do not need to search FFmpeg directories themselves — the symbols are already resolved inside the `gp` static library.