### PR TITLE
129: Fix Event::operator= silent data corruption on assignment

### DIFF
--- a/gp/_tests_/CMakeLists.txt
+++ b/gp/_tests_/CMakeLists.txt
@@ -12,3 +12,6 @@ set_target_properties(
 
 file(GLOB_RECURSE SDL_TESTS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/sdl_tests/*")
 add_test_target(sdl_tests FILES ${SDL_TESTS_FILES} DEPS utils gp)
+
+file(GLOB_RECURSE EVENT_TESTS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/event_tests/*")
+add_test_target(event_tests FILES ${EVENT_TESTS_FILES} DEPS gp)

--- a/gp/_tests_/event_tests/event_tests.cpp
+++ b/gp/_tests_/event_tests/event_tests.cpp
@@ -1,0 +1,97 @@
+#include <gp/misc/event.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+using gp::misc::Event;
+
+TEST(EventCopyAssign, SameType_Init_CopiesData) {
+  Event src{Event::Type::Init, 1u};
+  src.init().width = 1920;
+  src.init().height = 1080;
+
+  Event dst{Event::Type::Init, 0u};
+  dst = src;
+
+  EXPECT_EQ(dst.type(), Event::Type::Init);
+  EXPECT_EQ(dst.timestamp(), 1u);
+  EXPECT_EQ(dst.init().width, 1920);
+  EXPECT_EQ(dst.init().height, 1080);
+}
+
+TEST(EventCopyAssign, CrossType_InitToDragDrop_CopiesFilepath) {
+  Event src{Event::Type::DragDrop, 42u};
+  src.drag_drop().filepath = "/tmp/file.txt";
+
+  Event dst{Event::Type::Init, 0u};
+  dst.init().width = 800;
+  dst = src;
+
+  EXPECT_EQ(dst.type(), Event::Type::DragDrop);
+  EXPECT_EQ(dst.timestamp(), 42u);
+  EXPECT_EQ(dst.drag_drop().filepath, "/tmp/file.txt");
+}
+
+TEST(EventCopyAssign, CrossType_DragDropToKey_DestroysFilepath) {
+  Event src{Event::Type::Key, 7u};
+  src.key().action = Event::Action::Pressed;
+  src.key().scan_code = Event::ScanCode::A;
+
+  Event dst{Event::Type::DragDrop, 0u};
+  dst.drag_drop().filepath = "/tmp/old.txt";
+  dst = src;
+
+  EXPECT_EQ(dst.type(), Event::Type::Key);
+  EXPECT_EQ(dst.timestamp(), 7u);
+  EXPECT_EQ(dst.key().action, Event::Action::Pressed);
+  EXPECT_EQ(dst.key().scan_code, Event::ScanCode::A);
+}
+
+TEST(EventCopyAssign, SameType_DragDrop_CopiesFilepath) {
+  Event src{Event::Type::DragDrop, 10u};
+  src.drag_drop().filepath = "/home/user/drop.png";
+
+  Event dst{Event::Type::DragDrop, 0u};
+  dst.drag_drop().filepath = "/old/path.png";
+  dst = src;
+
+  EXPECT_EQ(dst.type(), Event::Type::DragDrop);
+  EXPECT_EQ(dst.drag_drop().filepath, "/home/user/drop.png");
+}
+
+TEST(EventCopyAssign, SelfAssign_DoesNotCrash) {
+  Event ev{Event::Type::DragDrop, 5u};
+  ev.drag_drop().filepath = "/self/assign.txt";
+
+  ev = ev; // NOLINT(clang-diagnostic-self-assign-overloaded)
+
+  EXPECT_EQ(ev.type(), Event::Type::DragDrop);
+  EXPECT_EQ(ev.drag_drop().filepath, "/self/assign.txt");
+}
+
+TEST(EventMoveAssign, CrossType_InitToDragDrop_MovesFilepath) {
+  Event src{Event::Type::DragDrop, 99u};
+  src.drag_drop().filepath = "/move/me.txt";
+
+  Event dst{Event::Type::Init, 0u};
+  dst = std::move(src);
+
+  EXPECT_EQ(dst.type(), Event::Type::DragDrop);
+  EXPECT_EQ(dst.timestamp(), 99u);
+  EXPECT_EQ(dst.drag_drop().filepath, "/move/me.txt");
+}
+
+TEST(EventMoveAssign, CrossType_DragDropToKey_DestroysFilepath) {
+  Event src{Event::Type::Key, 3u};
+  src.key().action = Event::Action::Released;
+  src.key().scan_code = Event::ScanCode::Escape;
+
+  Event dst{Event::Type::DragDrop, 0u};
+  dst.drag_drop().filepath = "/move/old.txt";
+  dst = std::move(src);
+
+  EXPECT_EQ(dst.type(), Event::Type::Key);
+  EXPECT_EQ(dst.key().action, Event::Action::Released);
+  EXPECT_EQ(dst.key().scan_code, Event::ScanCode::Escape);
+}
+} // namespace

--- a/gp/_tests_/event_tests/event_tests.cpp
+++ b/gp/_tests_/event_tests/event_tests.cpp
@@ -1,6 +1,7 @@
 #include <gp/misc/event.hpp>
 
 #include <gtest/gtest.h>
+#include <utility>
 
 namespace {
 using gp::misc::Event;

--- a/gp/misc/event.cpp
+++ b/gp/misc/event.cpp
@@ -29,10 +29,8 @@ Event::Event(Event &&other) noexcept
 
 Event &Event::operator=(const Event &other) {
   if (this != &other) {
-    destruct_complex_members();
-    type_ = other.type_;
-    timestamp_ = other.timestamp_;
-    copy(other);
+    Event temp(other);
+    *this = std::move(temp);
   }
   return *this;
 }
@@ -153,7 +151,7 @@ const Event::DragDropData &Event::drag_drop() const {
 
 void Event::copy(const Event &other) {
   assign_all(other);
-  switch (type()) {
+  switch (other.type()) {
   case Type::DragDrop:
     new (&drag_drop_.filepath) std::string(other.drag_drop().filepath);
     break;
@@ -164,7 +162,7 @@ void Event::copy(const Event &other) {
 
 void Event::move(Event &&other) {
   assign_all(other);
-  switch (type()) {
+  switch (other.type()) {
   case Type::DragDrop:
     new (&drag_drop_.filepath) std::string(std::move(other.drag_drop().filepath));
     break;
@@ -194,7 +192,7 @@ void Event::destruct_complex_members() {
 }
 
 void Event::assign_all(const Event &other) {
-  switch (type()) {
+  switch (other.type()) {
   case Type::None:
     break;
   case Type::Init:

--- a/gp/misc/event.cpp
+++ b/gp/misc/event.cpp
@@ -28,14 +28,22 @@ Event::Event(Event &&other) noexcept
 }
 
 Event &Event::operator=(const Event &other) {
-  destruct_complex_members();
-  copy(other);
+  if (this != &other) {
+    destruct_complex_members();
+    type_ = other.type_;
+    timestamp_ = other.timestamp_;
+    copy(other);
+  }
   return *this;
 }
 
 Event &Event::operator=(Event &&other) noexcept {
-  destruct_complex_members();
-  move(std::move(other));
+  if (this != &other) {
+    destruct_complex_members();
+    type_ = other.type_;
+    timestamp_ = other.timestamp_;
+    move(std::move(other));
+  }
   return *this;
 }
 

--- a/gp/misc/event.cpp
+++ b/gp/misc/event.cpp
@@ -1,6 +1,7 @@
 #include "event.hpp"
 
 #include <stdexcept>
+#include <utility>
 
 namespace gp::misc {
 bool Event::MouseMoveData::left_is_down() const { return mouse_button_mask & MouseButtonMask::Left; }


### PR DESCRIPTION
Closes #129

`Event::operator=(const Event&)` and `Event::operator=(Event&&)` called `destruct_complex_members()` and then `copy()`/`move()` without first updating `type_` and `timestamp_` from `other`. As a result, `assign_all()` switched on the old stale `type_`, copying the wrong union member — silent data corruption on every `Event` assignment where source and destination types differ.

**Fix:**
- Update `type_` and `timestamp_` from `other` between the destruct and copy/move calls
- Add self-assignment guard (`if (this != &other)`) to both overloads