### PR TITLE
128: Make GL RAII wrappers move-only — prevent double-delete on copy

### DIFF
--- a/gp/gl/buffer_object.cpp
+++ b/gp/gl/buffer_object.cpp
@@ -13,6 +13,22 @@ BufferObject::BufferObject(const GLenum target)
 
 BufferObject::~BufferObject() { glDeleteBuffers(1, &id_); }
 
+BufferObject::BufferObject(BufferObject &&other) noexcept
+    : id_{other.id_}
+    , target_{other.target_} {
+  other.id_ = 0;
+}
+
+BufferObject &BufferObject::operator=(BufferObject &&other) noexcept {
+  if (this != &other) {
+    glDeleteBuffers(1, &id_);
+    id_ = other.id_;
+    target_ = other.target_;
+    other.id_ = 0;
+  }
+  return *this;
+}
+
 GLuint BufferObject::id() const { return id_; }
 
 GLenum BufferObject::target() const { return target_; }

--- a/gp/gl/buffer_object.hpp
+++ b/gp/gl/buffer_object.hpp
@@ -19,6 +19,11 @@ public:
    */
   ~BufferObject();
 
+  BufferObject(const BufferObject &) = delete;
+  BufferObject &operator=(const BufferObject &) = delete;
+  BufferObject(BufferObject &&other) noexcept;
+  BufferObject &operator=(BufferObject &&other) noexcept;
+
   /**
    * @brief Returns the ID of the buffer object.
    * @return The ID of the buffer object.
@@ -109,6 +114,6 @@ public:
 
 private:
   GLuint id_{};
-  const GLenum target_{};
+  GLenum target_{};
 };
 } // namespace gp::gl

--- a/gp/gl/buffer_objects.cpp
+++ b/gp/gl/buffer_objects.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <utility>
 
 namespace gp::gl {
 BufferObjects::BufferObjects(const std::size_t n, const GLenum target)
@@ -14,6 +15,19 @@ BufferObjects::BufferObjects(const std::size_t n, const GLenum target)
 }
 
 BufferObjects::~BufferObjects() { glDeleteBuffers(static_cast<GLsizei>(ids_.size()), ids_.data()); }
+
+BufferObjects::BufferObjects(BufferObjects &&other) noexcept
+    : ids_(std::move(other.ids_))
+    , target_(other.target_) {}
+
+BufferObjects &BufferObjects::operator=(BufferObjects &&other) noexcept {
+  if (this != &other) {
+    glDeleteBuffers(static_cast<GLsizei>(ids_.size()), ids_.data());
+    ids_ = std::move(other.ids_);
+    target_ = other.target_;
+  }
+  return *this;
+}
 
 GLuint BufferObjects::id(const std::size_t index) const { return ids_[index]; }
 

--- a/gp/gl/buffer_objects.hpp
+++ b/gp/gl/buffer_objects.hpp
@@ -18,10 +18,12 @@ public:
    */
   BufferObjects(const std::size_t n, const GLenum target);
 
-  /**
-   * @brief Destroys the BufferObjects instance and releases all associated buffer objects.
-   */
   ~BufferObjects();
+
+  BufferObjects(BufferObjects &&other) noexcept;
+  BufferObjects &operator=(BufferObjects &&other) noexcept;
+  BufferObjects(const BufferObjects &) = delete;
+  BufferObjects &operator=(const BufferObjects &) = delete;
 
   /**
    * @brief Returns the ID of the buffer object at the specified index.
@@ -115,6 +117,6 @@ public:
 
 private:
   std::vector<GLuint> ids_{};
-  const GLenum target_{};
+  GLenum target_{};
 };
 } // namespace gp::gl

--- a/gp/gl/shader.cpp
+++ b/gp/gl/shader.cpp
@@ -17,6 +17,20 @@ Shader::Shader(const GLenum type, const std::string &code, const bool do_not_com
 
 Shader::~Shader() { glDeleteShader(id()); }
 
+Shader::Shader(Shader &&other) noexcept
+    : id_{other.id_} {
+  other.id_ = 0;
+}
+
+Shader &Shader::operator=(Shader &&other) noexcept {
+  if (this != &other) {
+    glDeleteShader(id());
+    id_ = other.id_;
+    other.id_ = 0;
+  }
+  return *this;
+}
+
 GLuint Shader::id() const { return id_; }
 
 void Shader::source(const std::string &code, const bool do_not_compile) const {

--- a/gp/gl/shader.hpp
+++ b/gp/gl/shader.hpp
@@ -29,6 +29,11 @@ public:
    */
   ~Shader();
 
+  Shader(const Shader &) = delete;
+  Shader &operator=(const Shader &) = delete;
+  Shader(Shader &&other) noexcept;
+  Shader &operator=(Shader &&other) noexcept;
+
   /**
    * @brief Returns the ID of the shader object.
    * @return The ID of the shader object.

--- a/gp/gl/shader_program.cpp
+++ b/gp/gl/shader_program.cpp
@@ -14,6 +14,22 @@ ShaderProgram::ShaderProgram() {
 
 ShaderProgram::~ShaderProgram() { glDeleteProgram(id()); }
 
+ShaderProgram::ShaderProgram(ShaderProgram &&other) noexcept
+    : id_{other.id_}
+    , uniform_locations_{std::move(other.uniform_locations_)} {
+  other.id_ = 0;
+}
+
+ShaderProgram &ShaderProgram::operator=(ShaderProgram &&other) noexcept {
+  if (this != &other) {
+    glDeleteProgram(id());
+    id_ = other.id_;
+    uniform_locations_ = std::move(other.uniform_locations_);
+    other.id_ = 0;
+  }
+  return *this;
+}
+
 GLuint ShaderProgram::id() const { return id_; }
 
 void ShaderProgram::use() const { glUseProgram(id()); }

--- a/gp/gl/shader_program.cpp
+++ b/gp/gl/shader_program.cpp
@@ -3,6 +3,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include <stdexcept>
+#include <utility>
 
 namespace gp::gl {
 ShaderProgram::ShaderProgram() {

--- a/gp/gl/shader_program.hpp
+++ b/gp/gl/shader_program.hpp
@@ -26,6 +26,11 @@ public:
    */
   ~ShaderProgram();
 
+  ShaderProgram(const ShaderProgram &) = delete;
+  ShaderProgram &operator=(const ShaderProgram &) = delete;
+  ShaderProgram(ShaderProgram &&other) noexcept;
+  ShaderProgram &operator=(ShaderProgram &&other) noexcept;
+
   /**
    * @brief Get the ID of the shader program.
    * @return The ID of the shader program.

--- a/gp/gl/texture_object.cpp
+++ b/gp/gl/texture_object.cpp
@@ -13,6 +13,22 @@ TextureObject::TextureObject(const GLenum target)
 
 TextureObject::~TextureObject() { glDeleteTextures(1, &id_); }
 
+TextureObject::TextureObject(TextureObject &&other) noexcept
+    : id_{other.id_}
+    , target_{other.target_} {
+  other.id_ = 0;
+}
+
+TextureObject &TextureObject::operator=(TextureObject &&other) noexcept {
+  if (this != &other) {
+    glDeleteTextures(1, &id_);
+    id_ = other.id_;
+    target_ = other.target_;
+    other.id_ = 0;
+  }
+  return *this;
+}
+
 GLuint TextureObject::id() const { return id_; }
 
 GLenum TextureObject::target() const { return target_; }

--- a/gp/gl/texture_object.hpp
+++ b/gp/gl/texture_object.hpp
@@ -21,6 +21,11 @@ public:
    */
   ~TextureObject();
 
+  TextureObject(const TextureObject &) = delete;
+  TextureObject &operator=(const TextureObject &) = delete;
+  TextureObject(TextureObject &&other) noexcept;
+  TextureObject &operator=(TextureObject &&other) noexcept;
+
   /**
    * @brief Returns the ID of the texture object.
    * @return The ID of the texture object.
@@ -128,6 +133,6 @@ public:
 
 private:
   GLuint id_{};
-  const GLenum target_{};
+  GLenum target_{};
 };
 } // namespace gp::gl

--- a/gp/gl/texture_objects.cpp
+++ b/gp/gl/texture_objects.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <utility>
 
 namespace gp::gl {
 TextureObjects::TextureObjects(const std::size_t n, const GLenum target)
@@ -14,6 +15,19 @@ TextureObjects::TextureObjects(const std::size_t n, const GLenum target)
 }
 
 TextureObjects::~TextureObjects() { glDeleteTextures(static_cast<GLsizei>(ids_.size()), ids_.data()); }
+
+TextureObjects::TextureObjects(TextureObjects &&other) noexcept
+    : ids_(std::move(other.ids_))
+    , target_(other.target_) {}
+
+TextureObjects &TextureObjects::operator=(TextureObjects &&other) noexcept {
+  if (this != &other) {
+    glDeleteTextures(static_cast<GLsizei>(ids_.size()), ids_.data());
+    ids_ = std::move(other.ids_);
+    target_ = other.target_;
+  }
+  return *this;
+}
 
 GLuint TextureObjects::id(const std::size_t index) const { return ids_[index]; }
 

--- a/gp/gl/texture_objects.hpp
+++ b/gp/gl/texture_objects.hpp
@@ -18,10 +18,12 @@ public:
    */
   TextureObjects(const std::size_t n, const GLenum target);
 
-  /**
-   * @brief Destroys the TextureObjects instance and releases all associated texture objects.
-   */
   ~TextureObjects();
+
+  TextureObjects(TextureObjects &&other) noexcept;
+  TextureObjects &operator=(TextureObjects &&other) noexcept;
+  TextureObjects(const TextureObjects &) = delete;
+  TextureObjects &operator=(const TextureObjects &) = delete;
 
   /**
    * @brief Returns the ID of the texture object at the specified index.
@@ -119,6 +121,6 @@ public:
 
 private:
   std::vector<GLuint> ids_{};
-  const GLenum target_{};
+  GLenum target_{};
 };
 } // namespace gp::gl

--- a/gp/gl/vertex_array_object.cpp
+++ b/gp/gl/vertex_array_object.cpp
@@ -12,6 +12,20 @@ VertexArrayObject::VertexArrayObject() {
 
 VertexArrayObject::~VertexArrayObject() { glDeleteVertexArrays(1, &id_); }
 
+VertexArrayObject::VertexArrayObject(VertexArrayObject &&other) noexcept
+    : id_{other.id_} {
+  other.id_ = 0;
+}
+
+VertexArrayObject &VertexArrayObject::operator=(VertexArrayObject &&other) noexcept {
+  if (this != &other) {
+    glDeleteVertexArrays(1, &id_);
+    id_ = other.id_;
+    other.id_ = 0;
+  }
+  return *this;
+}
+
 GLuint VertexArrayObject::id() const { return id_; }
 
 void VertexArrayObject::bind() const { glBindVertexArray(id()); }

--- a/gp/gl/vertex_array_object.hpp
+++ b/gp/gl/vertex_array_object.hpp
@@ -22,6 +22,11 @@ public:
    */
   ~VertexArrayObject();
 
+  VertexArrayObject(const VertexArrayObject &) = delete;
+  VertexArrayObject &operator=(const VertexArrayObject &) = delete;
+  VertexArrayObject(VertexArrayObject &&other) noexcept;
+  VertexArrayObject &operator=(VertexArrayObject &&other) noexcept;
+
   /**
    * @brief Returns the ID of the VertexArrayObject.
    * @return The ID of the VertexArrayObject.

--- a/gp/gl/vertex_array_objects.cpp
+++ b/gp/gl/vertex_array_objects.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <utility>
 
 namespace gp::gl {
 VertexArrayObjects::VertexArrayObjects(const std::size_t n)
@@ -13,6 +14,17 @@ VertexArrayObjects::VertexArrayObjects(const std::size_t n)
 }
 
 VertexArrayObjects::~VertexArrayObjects() { glDeleteVertexArrays(static_cast<GLsizei>(ids_.size()), ids_.data()); }
+
+VertexArrayObjects::VertexArrayObjects(VertexArrayObjects &&other) noexcept
+    : ids_(std::move(other.ids_)) {}
+
+VertexArrayObjects &VertexArrayObjects::operator=(VertexArrayObjects &&other) noexcept {
+  if (this != &other) {
+    glDeleteVertexArrays(static_cast<GLsizei>(ids_.size()), ids_.data());
+    ids_ = std::move(other.ids_);
+  }
+  return *this;
+}
 
 GLuint VertexArrayObjects::id(const std::size_t index) const { return ids_[index]; }
 

--- a/gp/gl/vertex_array_objects.hpp
+++ b/gp/gl/vertex_array_objects.hpp
@@ -20,10 +20,12 @@ public:
    */
   explicit VertexArrayObjects(const std::size_t n);
 
-  /**
-   * @brief Destructor for the VertexArrayObjects class.
-   */
   ~VertexArrayObjects();
+
+  VertexArrayObjects(VertexArrayObjects &&other) noexcept;
+  VertexArrayObjects &operator=(VertexArrayObjects &&other) noexcept;
+  VertexArrayObjects(const VertexArrayObjects &) = delete;
+  VertexArrayObjects &operator=(const VertexArrayObjects &) = delete;
 
   /**
    * @brief Returns the ID of the vertex array object at the specified index.


### PR DESCRIPTION
Closes #128

All five GL handle wrappers (`ShaderProgram`, `Shader`, `BufferObject`, `TextureObject`, `VertexArrayObject`) owned raw GL IDs and deleted them in their destructors, but the compiler-generated copy constructor and copy assignment duplicated the ID — causing two destructors to call `glDelete*` on the same ID, which is undefined behaviour.

**Fix:**
- Delete copy ctor and copy assign on all five classes
- Add `noexcept` move ctor and move assign (transfer ID, zero out the source's `id_`)
- Remove `const` from `target_` in `BufferObject` and `TextureObject` to allow move assignment
- No destructor guard needed: `glDelete*(0)` is a safe no-op per the OpenGL specification