### PR TITLE
124: Scope PUBLIC include dirs with BUILD_INTERFACE generator expression

### DIFF
--- a/ai/ai_common/CMakeLists.txt
+++ b/ai/ai_common/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(ai_common STATIC ${SRC_FILES})
 
 target_compile_features(ai_common PRIVATE cxx_std_23)
 
-target_include_directories(ai_common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(
+  ai_common PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
 target_link_libraries(ai_common PUBLIC gp)
 

--- a/gp/CMakeLists.txt
+++ b/gp/CMakeLists.txt
@@ -34,7 +34,8 @@ add_library(gp STATIC ${SRC_FILES})
 
 target_compile_features(gp PRIVATE cxx_std_23)
 
-target_include_directories(gp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(
+  gp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 target_include_directories(gp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(gp PUBLIC glm::glm)

--- a/streaming/streaming_common/CMakeLists.txt
+++ b/streaming/streaming_common/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(streaming_common STATIC ${SRC_FILES})
 
 target_compile_features(streaming_common PRIVATE cxx_std_23)
 
-target_include_directories(streaming_common
-                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(
+  streaming_common PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
 target_link_libraries(streaming_common PUBLIC gp)
 

--- a/wolf/wolf_common/CMakeLists.txt
+++ b/wolf/wolf_common/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(wolf_common STATIC ${SRC_FILES})
 
 target_compile_features(wolf_common PRIVATE cxx_std_23)
 
-target_include_directories(wolf_common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(
+  wolf_common PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
 target_link_libraries(wolf_common PUBLIC gp)
 


### PR DESCRIPTION
Closes #124

Using bare `${CMAKE_CURRENT_SOURCE_DIR}/..` as a `PUBLIC` include directory leaks the absolute source-tree path into any downstream install/export set.

Wrapping with `$<BUILD_INTERFACE:...>` limits the include path to build-tree consumers only — the correct modern CMake pattern for libraries without install rules.

**Affected targets:** `gp`, `ai_common`, `wolf_common`, `streaming_common`