### PR TITLE
132: Fix streaming thread safety, null dereferences, and JSON error handling

### DIFF
--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -114,31 +114,33 @@ void Encoder::encode() {
 }
 
 void Encoder::encode_frame(AVFrame *frame) {
-  auto result = avcodec_send_frame(context_, frame);
-  if (result < 0) {
+  const auto send_result = avcodec_send_frame(context_, frame);
+  if (send_result < 0) {
     throw std::runtime_error{"avcodec_send_frame failed"};
   }
 
-  while (result == 0) {
-    result = avcodec_receive_packet(context_, packet_);
-    if (result == 0) {
-      if (video_stream_callback_) {
-        video_stream_callback_(reinterpret_cast<const std::byte *>(packet_->data),
-                               static_cast<std::size_t>(packet_->size),
-                               false);
-      }
-      av_packet_unref(packet_);
-    } else if (result == AVERROR(EAGAIN)) {
-      continue;
-    } else if (result == AVERROR_EOF) {
+  for (;;) {
+    const auto rc = avcodec_receive_packet(context_, packet_);
+    if (rc == AVERROR(EAGAIN)) {
+      break;
+    }
+    if (rc == AVERROR_EOF) {
       if (video_stream_callback_) {
         static constexpr std::array<uint8_t, 4> endcode{0, 0, 1, 0xb7};
         video_stream_callback_(reinterpret_cast<const std::byte *>(endcode.data()), sizeof(endcode), true);
       }
       av_packet_unref(packet_);
-    } else {
-      throw std::runtime_error{"avcodec_receive_packet failed: Unknown error"};
+      break;
     }
+    if (rc < 0) {
+      throw std::runtime_error{"avcodec_receive_packet failed"};
+    }
+    if (video_stream_callback_) {
+      video_stream_callback_(reinterpret_cast<const std::byte *>(packet_->data),
+                             static_cast<std::size_t>(packet_->size),
+                             false);
+    }
+    av_packet_unref(packet_);
   }
 }
 

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <stdexcept>
+#include <string>
 
 namespace streaming {
 Encoder::Encoder(const VideoStreamInfo &video_stream_info)
@@ -114,33 +115,47 @@ void Encoder::encode() {
 }
 
 void Encoder::encode_frame(AVFrame *frame) {
-  const auto send_result = avcodec_send_frame(context_, frame);
-  if (send_result < 0) {
-    throw std::runtime_error{"avcodec_send_frame failed"};
-  }
-
   for (;;) {
-    const auto rc = avcodec_receive_packet(context_, packet_);
-    if (rc == AVERROR(EAGAIN)) {
-      break;
+    const auto send_result = avcodec_send_frame(context_, frame);
+    if (send_result == AVERROR_EOF) {
+      return;
     }
-    if (rc == AVERROR_EOF) {
-      if (video_stream_callback_) {
-        static constexpr std::array<uint8_t, 4> endcode{0, 0, 1, 0xb7};
-        video_stream_callback_(reinterpret_cast<const std::byte *>(endcode.data()), sizeof(endcode), true);
+    if (send_result < 0 && send_result != AVERROR(EAGAIN)) {
+      char errbuf[AV_ERROR_MAX_STRING_SIZE]{};
+      av_strerror(send_result, errbuf, sizeof(errbuf));
+      throw std::runtime_error{std::string{"avcodec_send_frame failed: "} + errbuf};
+    }
+
+    bool drained = false;
+    while (!drained) {
+      const auto rc = avcodec_receive_packet(context_, packet_);
+      if (rc == AVERROR(EAGAIN)) {
+        drained = true;
+      } else if (rc == AVERROR_EOF) {
+        if (video_stream_callback_) {
+          static constexpr std::array<uint8_t, 4> endcode{0, 0, 1, 0xb7};
+          video_stream_callback_(reinterpret_cast<const std::byte *>(endcode.data()), sizeof(endcode), true);
+        }
+        av_packet_unref(packet_);
+        return;
+      } else if (rc < 0) {
+        char errbuf[AV_ERROR_MAX_STRING_SIZE]{};
+        av_strerror(rc, errbuf, sizeof(errbuf));
+        throw std::runtime_error{std::string{"avcodec_receive_packet failed: "} + errbuf};
+      } else {
+        if (video_stream_callback_) {
+          video_stream_callback_(reinterpret_cast<const std::byte *>(packet_->data),
+                                 static_cast<std::size_t>(packet_->size),
+                                 false);
+        }
+        av_packet_unref(packet_);
       }
-      av_packet_unref(packet_);
-      break;
     }
-    if (rc < 0) {
-      throw std::runtime_error{"avcodec_receive_packet failed"};
+
+    if (send_result == 0) {
+      return;
     }
-    if (video_stream_callback_) {
-      video_stream_callback_(reinterpret_cast<const std::byte *>(packet_->data),
-                             static_cast<std::size_t>(packet_->size),
-                             false);
-    }
-    av_packet_unref(packet_);
+    // send_result == AVERROR(EAGAIN): drained, retry send
   }
 }
 

--- a/streaming/streaming_receiver/main.cpp
+++ b/streaming/streaming_receiver/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
   }
 
   auto decode_scene = std::make_unique<streaming::DecodeScene>();
-  auto receiver = std::make_unique<streaming::Receiver>(program_setup.ip, program_setup.port);
+  auto receiver = std::make_shared<streaming::Receiver>(program_setup.ip, program_setup.port);
 
   receiver->set_video_stream_info_callback(
       [&decode_scene](const streaming::VideoStreamInfo &video_stream_info) { decode_scene->init(video_stream_info); });

--- a/streaming/streaming_receiver/receiver.cpp
+++ b/streaming/streaming_receiver/receiver.cpp
@@ -12,20 +12,27 @@ Receiver::Receiver(const std::string &server_ip, const std::uint16_t server_port
   configuration_.maxMessageSize = MAX_MESSAGE_SIZE;
 
   web_socket_ = std::make_shared<rtc::WebSocket>();
-  init_web_socket(web_socket_);
   connection_url_ = std::string{"ws://"} + server_ip + ":" + std::to_string(server_port) + "/" + id_;
   printf("Connection url: %s\n", connection_url_.c_str());
 }
 
-void Receiver::connect() { web_socket_->open(connection_url_); }
+void Receiver::connect() {
+  init_web_socket(web_socket_);
+  web_socket_->open(connection_url_);
+}
 
 void Receiver::handle_event(const gp::misc::Event &event) {
-  if (peer_ && peer_->data_channel && peer_->data_channel->isOpen()) {
+  std::shared_ptr<Peer> peer;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    peer = peer_;
+  }
+  if (peer && peer->data_channel && peer->data_channel->isOpen()) {
     const auto json_event = gp::json::from_event(event);
     const auto json = nlohmann::json{
         {"event", json_event}
     };
-    peer_->data_channel->send(json.dump());
+    peer->data_channel->send(json.dump());
   }
 }
 
@@ -40,19 +47,33 @@ void Receiver::set_incoming_video_stream_data_callback(
 }
 
 void Receiver::init_web_socket(std::shared_ptr<rtc::WebSocket> web_socket) {
-  auto on_web_socket_open_function = std::function<void()>{std::bind(&Receiver::on_web_socket_open, this)};
-  auto on_web_socket_closed_function = std::function<void()>{std::bind(&Receiver::on_web_socket_closed, this)};
-  auto on_web_socket_error_function =
-      std::function<void(std::string error)>{std::bind(&Receiver::on_web_socket_error, this, std::placeholders::_1)};
-  auto on_web_socket_binary_message_function = std::function<void(rtc::binary message)>{
-      std::bind(&Receiver::on_web_socket_binary_message, this, std::placeholders::_1)};
-  auto on_web_socket_string_message_function = std::function<void(std::string message)>{
-      std::bind(&Receiver::on_web_socket_string_message, this, std::placeholders::_1)};
-
-  web_socket->onOpen(on_web_socket_open_function);
-  web_socket->onClosed(on_web_socket_closed_function);
-  web_socket->onError(on_web_socket_error_function);
-  web_socket->onMessage(on_web_socket_binary_message_function, on_web_socket_string_message_function);
+  auto weak_self = weak_from_this();
+  web_socket->onOpen([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_web_socket_open();
+    }
+  });
+  web_socket->onClosed([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_web_socket_closed();
+    }
+  });
+  web_socket->onError([weak_self](std::string error) {
+    if (auto self = weak_self.lock()) {
+      self->on_web_socket_error(std::move(error));
+    }
+  });
+  web_socket->onMessage(
+      [weak_self](rtc::binary message) {
+        if (auto self = weak_self.lock()) {
+          self->on_web_socket_binary_message(std::move(message));
+        }
+      },
+      [weak_self](std::string message) {
+        if (auto self = weak_self.lock()) {
+          self->on_web_socket_string_message(std::move(message));
+        }
+      });
 }
 
 void Receiver::on_web_socket_open() {
@@ -73,26 +94,35 @@ void Receiver::on_web_socket_binary_message(rtc::binary /* message */) {
 }
 
 void Receiver::on_web_socket_string_message(std::string message) {
-  auto json = nlohmann::json::parse(message);
+  try {
+    auto json = nlohmann::json::parse(message);
 
-  if (json.contains("id") && json.contains("type") && json.contains("sdp")) {
-    std::string id = json.at("id");
-    std::string type = json.at("type");
-    std::string sdp = json.at("sdp");
+    if (json.contains("id") && json.contains("type") && json.contains("sdp")) {
+      std::string id = json.at("id");
+      std::string type = json.at("type");
+      std::string sdp = json.at("sdp");
 
-    if (type == "offer") {
-      peer_ = create_peer(id);
-      auto connection = peer_->connection;
-      auto description = rtc::Description{sdp, type};
-      peer_->connection->setRemoteDescription(description);
+      if (type == "offer") {
+        auto new_peer = create_peer(id);
+        std::shared_ptr<Peer> peer;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          peer_ = new_peer;
+          peer = peer_;
+        }
+        auto description = rtc::Description{sdp, type};
+        peer->connection->setRemoteDescription(description);
+        return;
+      }
+    } else if (json.contains("video_stream_infos")) {
+      parse_video_stream_infos(json.at("video_stream_infos"));
       return;
     }
-  } else if (json.contains("video_stream_infos")) {
-    parse_video_stream_infos(json.at("video_stream_infos"));
-    return;
-  }
 
-  printf("Unknown message: %s\n", message.c_str());
+    printf("Unknown message: %s\n", message.c_str());
+  } catch (const std::exception &e) {
+    printf("Error processing message: %s\n", e.what());
+  }
 }
 
 void Receiver::on_peer_state_change(rtc::PeerConnection::State state) {
@@ -103,18 +133,24 @@ void Receiver::on_peer_state_change(rtc::PeerConnection::State state) {
   case rtc::PeerConnection::State::Connected:
     printf("Peer state: Connected\n");
     break;
-  case rtc::PeerConnection::State::Disconnected:
+  case rtc::PeerConnection::State::Disconnected: {
     printf("Peer state: Disconnected\n");
+    std::lock_guard<std::mutex> lock(mutex_);
     peer_ = nullptr;
     break;
-  case rtc::PeerConnection::State::Failed:
+  }
+  case rtc::PeerConnection::State::Failed: {
     printf("Peer state: Failed\n");
+    std::lock_guard<std::mutex> lock(mutex_);
     peer_ = nullptr;
     break;
-  case rtc::PeerConnection::State::Closed:
+  }
+  case rtc::PeerConnection::State::Closed: {
     printf("Peer state: Closed\n");
+    std::lock_guard<std::mutex> lock(mutex_);
     peer_ = nullptr;
     break;
+  }
 
   default:
     break;
@@ -123,9 +159,17 @@ void Receiver::on_peer_state_change(rtc::PeerConnection::State state) {
 
 void Receiver::on_peer_gathering_state_change(rtc::PeerConnection::GatheringState state) {
   if (state == rtc::PeerConnection::GatheringState::Complete) {
-    auto description = peer_->connection->localDescription();
+    std::shared_ptr<Peer> peer;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      peer = peer_;
+    }
+    if (!peer) {
+      return;
+    }
+    auto description = peer->connection->localDescription();
     const auto json = nlohmann::json{
-        {  "id",                        peer_->id},
+        {  "id",                         peer->id},
         {"type",        description->typeString()},
         { "sdp", std::string(description.value())}
     };
@@ -134,8 +178,16 @@ void Receiver::on_peer_gathering_state_change(rtc::PeerConnection::GatheringStat
 }
 
 void Receiver::on_peer_local_description(rtc::Description description) {
+  std::shared_ptr<Peer> peer;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    peer = peer_;
+  }
+  if (!peer) {
+    return;
+  }
   const auto json = nlohmann::json{
-      {         "id",                peer_->id},
+      {         "id",                 peer->id},
       {       "type", description.typeString()},
       {"description", std::string(description)}
   };
@@ -143,8 +195,16 @@ void Receiver::on_peer_local_description(rtc::Description description) {
 }
 
 void Receiver::on_peer_local_candidate(rtc::Candidate candidate) {
+  std::shared_ptr<Peer> peer;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    peer = peer_;
+  }
+  if (!peer) {
+    return;
+  }
   const auto json = nlohmann::json{
-      {       "id",              peer_->id},
+      {       "id",               peer->id},
       {     "type",            "candidate"},
       {"candidate", std::string(candidate)},
       {      "mid",        candidate.mid()}
@@ -153,21 +213,38 @@ void Receiver::on_peer_local_candidate(rtc::Candidate candidate) {
 }
 
 void Receiver::on_peer_data_channel(std::shared_ptr<rtc::DataChannel> data_channel) {
-  peer_->data_channel = data_channel;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    peer_->data_channel = data_channel;
+  }
 
-  auto on_data_channel_open_function = std::function<void()>{std::bind(&Receiver::on_data_channel_open, this)};
-  auto on_data_channel_closed_function = std::function<void()>{std::bind(&Receiver::on_data_channel_closed, this)};
-  auto on_data_channel_error_function =
-      std::function<void(std::string error)>{std::bind(&Receiver::on_data_channel_error, this, std::placeholders::_1)};
-  auto on_data_channel_binary_message_function = std::function<void(rtc::binary message)>{
-      std::bind(&Receiver::on_data_channel_binary_message, this, std::placeholders::_1)};
-  auto on_data_channel_string_message_function = std::function<void(std::string message)>{
-      std::bind(&Receiver::on_data_channel_string_message, this, std::placeholders::_1)};
-
-  peer_->data_channel->onOpen(on_data_channel_open_function);
-  peer_->data_channel->onClosed(on_data_channel_closed_function);
-  peer_->data_channel->onError(on_data_channel_error_function);
-  peer_->data_channel->onMessage(on_data_channel_binary_message_function, on_data_channel_string_message_function);
+  auto weak_self = weak_from_this();
+  data_channel->onOpen([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_data_channel_open();
+    }
+  });
+  data_channel->onClosed([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_data_channel_closed();
+    }
+  });
+  data_channel->onError([weak_self](std::string error) {
+    if (auto self = weak_self.lock()) {
+      self->on_data_channel_error(std::move(error));
+    }
+  });
+  data_channel->onMessage(
+      [weak_self](rtc::binary message) {
+        if (auto self = weak_self.lock()) {
+          self->on_data_channel_binary_message(std::move(message));
+        }
+      },
+      [weak_self](std::string message) {
+        if (auto self = weak_self.lock()) {
+          self->on_data_channel_string_message(std::move(message));
+        }
+      });
 }
 
 void Receiver::on_data_channel_open() { printf("Data channel opened\n"); }
@@ -193,21 +270,32 @@ std::shared_ptr<Receiver::Peer> Receiver::create_peer(const std::string &id) {
   peer->id = id;
   peer->connection = std::make_shared<rtc::PeerConnection>(configuration_);
 
-  auto on_peer_state_change_function = std::function<void(rtc::PeerConnection::State state)>{
-      std::bind(&Receiver::on_peer_state_change, this, std::placeholders::_1)};
-  auto on_peer_gathering_state_change_function = std::function<void(rtc::PeerConnection::GatheringState state)>{
-      std::bind(&Receiver::on_peer_gathering_state_change, this, std::placeholders::_1)};
-  auto on_peer_local_description_function = std::function<void(rtc::Description description)>{
-      std::bind(&Receiver::on_peer_local_description, this, std::placeholders::_1)};
-  auto on_peer_local_candidate_function = std::function<void(rtc::Candidate candidate)>{
-      std::bind(&Receiver::on_peer_local_candidate, this, std::placeholders::_1)};
-  auto on_peer_data_channel_function = std::function<void(std::shared_ptr<rtc::DataChannel> data_channel)>{
-      std::bind(&Receiver::on_peer_data_channel, this, std::placeholders::_1)};
-  peer->connection->onStateChange(on_peer_state_change_function);
-  peer->connection->onGatheringStateChange(on_peer_gathering_state_change_function);
-  peer->connection->onLocalDescription(on_peer_local_description_function);
-  peer->connection->onLocalCandidate(on_peer_local_candidate_function);
-  peer->connection->onDataChannel(on_peer_data_channel_function);
+  auto weak_self = weak_from_this();
+  peer->connection->onStateChange([weak_self](rtc::PeerConnection::State state) {
+    if (auto self = weak_self.lock()) {
+      self->on_peer_state_change(state);
+    }
+  });
+  peer->connection->onGatheringStateChange([weak_self](rtc::PeerConnection::GatheringState state) {
+    if (auto self = weak_self.lock()) {
+      self->on_peer_gathering_state_change(state);
+    }
+  });
+  peer->connection->onLocalDescription([weak_self](rtc::Description description) {
+    if (auto self = weak_self.lock()) {
+      self->on_peer_local_description(std::move(description));
+    }
+  });
+  peer->connection->onLocalCandidate([weak_self](rtc::Candidate candidate) {
+    if (auto self = weak_self.lock()) {
+      self->on_peer_local_candidate(std::move(candidate));
+    }
+  });
+  peer->connection->onDataChannel([weak_self](std::shared_ptr<rtc::DataChannel> data_channel) {
+    if (auto self = weak_self.lock()) {
+      self->on_peer_data_channel(std::move(data_channel));
+    }
+  });
 
   return peer;
 }
@@ -235,22 +323,26 @@ void Receiver::command_request_video_stream(const std::string &streamer_id) {
 }
 
 void Receiver::parse_video_stream_infos(const nlohmann::json &json_video_stream_infos) {
-  streamer_infos_.clear();
-  for (auto it = json_video_stream_infos.begin(); it != json_video_stream_infos.end(); ++it) {
-    streamer_infos_.emplace_back();
-    streamer_infos_.back().streamer_id = it->at("streamer_id");
-    streamer_infos_.back().video_stream_info.width = it->at("width");
-    streamer_infos_.back().video_stream_info.height = it->at("height");
-    streamer_infos_.back().video_stream_info.fps = it->at("fps");
-    streamer_infos_.back().video_stream_info.codec_id = it->at("codec_id");
-    streamer_infos_.back().video_stream_info.codec_name = it->at("codec_name");
+  try {
+    streamer_infos_.clear();
+    for (auto it = json_video_stream_infos.begin(); it != json_video_stream_infos.end(); ++it) {
+      streamer_infos_.emplace_back();
+      streamer_infos_.back().streamer_id = it->at("streamer_id");
+      streamer_infos_.back().video_stream_info.width = it->at("width");
+      streamer_infos_.back().video_stream_info.height = it->at("height");
+      streamer_infos_.back().video_stream_info.fps = it->at("fps");
+      streamer_infos_.back().video_stream_info.codec_id = it->at("codec_id");
+      streamer_infos_.back().video_stream_info.codec_name = it->at("codec_name");
 
-    if (video_stream_info_callback_) {
-      video_stream_info_callback_(streamer_infos_.back().video_stream_info);
-    } else {
-      throw std::runtime_error("Video stream info callback not set");
+      if (video_stream_info_callback_) {
+        video_stream_info_callback_(streamer_infos_.back().video_stream_info);
+      } else {
+        throw std::runtime_error("Video stream info callback not set");
+      }
+      command_request_video_stream(streamer_infos_.back().streamer_id);
     }
-    command_request_video_stream(streamer_infos_.back().streamer_id);
+  } catch (const std::exception &e) {
+    printf("Error parsing video stream infos: %s\n", e.what());
   }
 }
 } // namespace streaming

--- a/streaming/streaming_receiver/receiver.hpp
+++ b/streaming/streaming_receiver/receiver.hpp
@@ -7,14 +7,16 @@
 #include <nlohmann/json.hpp>
 #include <rtc/rtc.hpp>
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
 namespace streaming {
-class Receiver {
+class Receiver : public std::enable_shared_from_this<Receiver> {
 public:
   Receiver(const Receiver &) = delete;
   Receiver &operator=(const Receiver &) = delete;
@@ -70,12 +72,13 @@ private:
 
   const std::string receiver_id_{};
   const std::string id_{};
-  bool connection_open_{false};
+  std::atomic<bool> connection_open_{false};
   rtc::Configuration configuration_{};
   std::string connection_url_;
   std::shared_ptr<rtc::WebSocket> web_socket_{};
   std::shared_ptr<Peer> peer_{};
   std::vector<StreamerInfo> streamer_infos_{};
+  mutable std::mutex mutex_{};
 
   std::function<void(const VideoStreamInfo &video_stream_info)> video_stream_info_callback_{};
   std::function<void(const std::byte *data, const std::size_t size)> incoming_video_stream_data_callback_{};

--- a/streaming/streaming_signaling_server/server.cpp
+++ b/streaming/streaming_signaling_server/server.cpp
@@ -18,6 +18,7 @@ void Server::on_client(std::shared_ptr<rtc::WebSocket> incoming) {
   if (auto remote_address = client->web_socket->remoteAddress()) {
     printf("Client connection received: %s\n", remote_address->c_str());
     init_client(client);
+    std::lock_guard<std::mutex> lock(mutex_);
     temporary_store_.insert(client);
   }
 }
@@ -42,7 +43,14 @@ void Server::init_client(std::shared_ptr<Client> &client) {
 
 void Server::on_client_open(std::weak_ptr<Client> weak_client) {
   auto client = weak_client.lock();
-  temporary_store_.erase(client);
+  if (!client) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    temporary_store_.erase(client);
+  }
 
   if (auto remote_address = client->web_socket->remoteAddress()) {
     printf("Client connection opened: %s\n", remote_address->c_str());
@@ -50,6 +58,7 @@ void Server::on_client_open(std::weak_ptr<Client> weak_client) {
     if (auto path = client->web_socket->path()) {
       client->info.parse(*path);
 
+      std::lock_guard<std::mutex> lock(mutex_);
       switch (client->info.type()) {
       case Client::Type::unknown:
         printf("Unknown client connected\n  ignoring... connection will be closed\n");
@@ -71,31 +80,37 @@ void Server::on_client_open(std::weak_ptr<Client> weak_client) {
 
 void Server::on_client_closed(std::weak_ptr<Client> weak_client) {
   auto type = Client::Type::unknown;
+  std::string id;
 
   auto client = weak_client.lock();
   if (client) {
     type = client->info.type();
+    id = client->info.id();
   }
 
+  std::lock_guard<std::mutex> lock(mutex_);
   switch (type) {
   case Client::Type::unknown:
     printf("Unknown client disconnected\n");
     break;
   case Client::Type::streamer:
-    printf("Streamer '%s' disconnected\n", client->info.id().c_str());
-    streamers_.erase(client->info.id());
-    clients_.erase(client->info.id());
+    printf("Streamer '%s' disconnected\n", id.c_str());
+    streamers_.erase(id);
+    clients_.erase(id);
     break;
   case Client::Type::receiver:
-    printf("Receiver '%s' disconnected\n", client->info.id().c_str());
-    receivers_.erase(client->info.id());
-    clients_.erase(client->info.id());
+    printf("Receiver '%s' disconnected\n", id.c_str());
+    receivers_.erase(id);
+    clients_.erase(id);
     break;
   }
 }
 
 void Server::on_client_error(std::weak_ptr<Client> weak_client, std::string error) const {
   auto client = weak_client.lock();
+  if (!client) {
+    return;
+  }
 
   switch (client->info.type()) {
   case Client::Type::unknown:
@@ -116,109 +131,173 @@ void Server::on_client_binary_message(std::weak_ptr<Client> /* weak_client */, r
 
 void Server::on_client_string_message(std::weak_ptr<Client> weak_client, std::string message) {
   auto client = weak_client.lock();
-  auto json = nlohmann::json::parse(message);
-
-  if (json.contains("video_stream_info")) {
-    parse_video_stream_info(client, json.at("video_stream_info"));
-
-    send_video_stream_infos_to_unpaired_receivers();
+  if (!client) {
     return;
   }
 
-  if (json.contains("command")) {
-    parse_command(client, json.at("command"));
-    return;
-  }
+  try {
+    auto json = nlohmann::json::parse(message);
 
-  if (json.contains("id") && json.contains("type") && json.contains("sdp")) {
-    std::string id = json.at("id");
-    std::string type = json.at("type");
-    std::string sdp = json.at("sdp");
-
-    if (type == "offer") {
-      auto response_json = nlohmann::json{
-          {  "id", client->info.id()},
-          {"type",              type},
-          { "sdp",               sdp}
-      };
-      clients_[id]->web_socket->send(response_json.dump());
+    if (json.contains("video_stream_info")) {
+      parse_video_stream_info(client, json.at("video_stream_info"));
+      send_video_stream_infos_to_unpaired_receivers();
       return;
     }
-    if (type == "answer") {
-      auto response_json = nlohmann::json{
-          {  "id", client->info.id()},
-          {"type",              type},
-          { "sdp",               sdp}
-      };
-      clients_[id]->web_socket->send(response_json.dump());
+
+    if (json.contains("command")) {
+      parse_command(client, json.at("command"));
       return;
     }
-  }
 
-  printf("Unknown message: %s\n", message.c_str());
+    if (json.contains("id") && json.contains("type") && json.contains("sdp")) {
+      std::string id = json.at("id");
+      std::string type = json.at("type");
+      std::string sdp = json.at("sdp");
+
+      if (type == "offer") {
+        std::shared_ptr<Client> target_client;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          auto it = clients_.find(id);
+          if (it != clients_.end()) {
+            target_client = it->second;
+          }
+        }
+        if (!target_client) {
+          printf("Unknown message: %s\n", message.c_str());
+          return;
+        }
+        auto response_json = nlohmann::json{
+            {  "id", client->info.id()},
+            {"type",              type},
+            { "sdp",               sdp}
+        };
+        target_client->web_socket->send(response_json.dump());
+        return;
+      }
+      if (type == "answer") {
+        std::shared_ptr<Client> target_client;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          auto it = clients_.find(id);
+          if (it != clients_.end()) {
+            target_client = it->second;
+          }
+        }
+        if (!target_client) {
+          printf("Unknown message: %s\n", message.c_str());
+          return;
+        }
+        auto response_json = nlohmann::json{
+            {  "id", client->info.id()},
+            {"type",              type},
+            { "sdp",               sdp}
+        };
+        target_client->web_socket->send(response_json.dump());
+        return;
+      }
+    }
+
+    printf("Unknown message: %s\n", message.c_str());
+  } catch (const std::exception &e) {
+    printf("Error processing message: %s\n", e.what());
+  }
 }
 
 void Server::parse_video_stream_info(std::shared_ptr<Client> &client, const nlohmann::json &json_video_stream_info) {
-  auto &video_stream_info = streamers_[client->info.id()].video_stream_info;
-  video_stream_info.width = json_video_stream_info.at("width");
-  video_stream_info.height = json_video_stream_info.at("height");
-  video_stream_info.fps = json_video_stream_info.at("fps");
-  video_stream_info.codec_id = json_video_stream_info.at("codec_id");
-  video_stream_info.codec_name = json_video_stream_info.at("codec_name");
+  try {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto &video_stream_info = streamers_[client->info.id()].video_stream_info;
+    video_stream_info.width = json_video_stream_info.at("width");
+    video_stream_info.height = json_video_stream_info.at("height");
+    video_stream_info.fps = json_video_stream_info.at("fps");
+    video_stream_info.codec_id = json_video_stream_info.at("codec_id");
+    video_stream_info.codec_name = json_video_stream_info.at("codec_name");
+  } catch (const std::exception &e) {
+    printf("Error parsing video stream info: %s\n", e.what());
+  }
 }
 
 void Server::parse_command(std::shared_ptr<Client> &client, const nlohmann::json &json_command) {
-  const auto type = std::string{json_command.at("type")};
-  if (type == "request_video_stream_infos") {
-    send_video_stream_infos(client);
-    return;
-  }
-  if (type == "request_video_stream") {
-    const auto streamer = std::string{json_command.at("streamer")};
-    const auto receiver = std::string{json_command.at("receiver")};
+  try {
+    const auto type = std::string{json_command.at("type")};
+    if (type == "request_video_stream_infos") {
+      send_video_stream_infos(client);
+      return;
+    }
+    if (type == "request_video_stream") {
+      const auto streamer = std::string{json_command.at("streamer")};
+      const auto receiver = std::string{json_command.at("receiver")};
 
-    const auto request_video_stream_json = nlohmann::json{
-        {"streamer", streamer},
-        {"receiver", receiver}
-    };
-    const auto json = nlohmann::json{
-        {"request_video_stream", request_video_stream_json}
-    };
-    clients_[streamer]->web_socket->send(json.dump());
-    return;
+      std::shared_ptr<Client> streamer_client;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = clients_.find(streamer);
+        if (it != clients_.end()) {
+          streamer_client = it->second;
+        }
+      }
+
+      if (!streamer_client) {
+        printf("Unknown message: %s\n", json_command.dump().c_str());
+        return;
+      }
+
+      const auto request_video_stream_json = nlohmann::json{
+          {"streamer", streamer},
+          {"receiver", receiver}
+      };
+      const auto json = nlohmann::json{
+          {"request_video_stream", request_video_stream_json}
+      };
+      streamer_client->web_socket->send(json.dump());
+      return;
+    }
+    printf("Unknown command: %s\n", json_command.dump().c_str());
+  } catch (const std::exception &e) {
+    printf("Error processing command: %s\n", e.what());
   }
-  printf("Unknown command: %s\n", json_command.dump().c_str());
 }
 
 void Server::send_video_stream_infos_to_unpaired_receivers() {
-  for (const auto &receiver_pair : receivers_) {
-    const auto &receiver = receiver_pair.second;
-    if (receiver.paired) {
-      continue;
+  std::vector<std::shared_ptr<Client>> clients_to_update;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto &receiver_pair : receivers_) {
+      const auto &receiver = receiver_pair.second;
+      if (receiver.paired) {
+        continue;
+      }
+      auto client_it = clients_.find(receiver.id);
+      if (client_it != clients_.end()) {
+        clients_to_update.push_back(client_it->second);
+      }
     }
-    auto client_it = clients_.find(receiver.id);
-    if (client_it != clients_.end()) {
-      send_video_stream_infos(client_it->second);
-    }
+  }
+  for (auto &receiver_client : clients_to_update) {
+    send_video_stream_infos(receiver_client);
   }
 }
 
 void Server::send_video_stream_infos(std::shared_ptr<Client> &client) {
   auto video_stream_infos_json = nlohmann::json::array();
-  for (const auto &streamer_pair : streamers_) {
-    const auto &streamer = streamer_pair.second;
-    if (streamer.paired) {
-      continue;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto &streamer_pair : streamers_) {
+      const auto &streamer = streamer_pair.second;
+      if (streamer.paired) {
+        continue;
+      }
+      const auto video_stream_info_json = nlohmann::json{
+          {"streamer_id",                           streamer.id},
+          {      "width",      streamer.video_stream_info.width},
+          {     "height",     streamer.video_stream_info.height},
+          {        "fps",        streamer.video_stream_info.fps},
+          {   "codec_id",   streamer.video_stream_info.codec_id},
+          { "codec_name", streamer.video_stream_info.codec_name}
+      };
+      video_stream_infos_json.push_back(video_stream_info_json);
     }
-    const auto video_stream_info_json = nlohmann::json{
-        {"streamer_id",                           streamer.id},
-        {      "width",      streamer.video_stream_info.width},
-        {     "height",     streamer.video_stream_info.height},
-        {        "fps",        streamer.video_stream_info.fps},
-        {   "codec_id",   streamer.video_stream_info.codec_id},
-        { "codec_name", streamer.video_stream_info.codec_name}
-    };
-    video_stream_infos_json.push_back(video_stream_info_json);
   }
   const auto json = nlohmann::json{
       {"video_stream_infos", video_stream_infos_json}

--- a/streaming/streaming_signaling_server/server.hpp
+++ b/streaming/streaming_signaling_server/server.hpp
@@ -8,6 +8,7 @@
 #include <rtc/rtc.hpp>
 
 #include <memory>
+#include <mutex>
 #include <unordered_set>
 
 namespace streaming {
@@ -52,5 +53,6 @@ private:
   std::unordered_map<std::string, std::shared_ptr<Client>> clients_{};
   std::unordered_map<std::string, StreamerInfo> streamers_{};
   std::unordered_map<std::string, ReceiverInfo> receivers_{};
+  mutable std::mutex mutex_{};
 };
 } // namespace streaming

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -72,9 +72,10 @@ int main(int argc, char *argv[]) {
                                                             avcodec_get_name(program_setup.codec_id)};
 
   auto encode_scene = std::make_unique<streaming::EncodeScene>(video_stream_info);
-  auto streamer = std::make_unique<streaming::Streamer>(program_setup.ip, program_setup.port, encode_scene->encoder());
+  auto streamer = std::make_shared<streaming::Streamer>(program_setup.ip, program_setup.port);
 
   streamer->set_event_callback([&encode_scene](const gp::misc::Event &event) { encode_scene->handle_event(event); });
+  streamer->start(encode_scene->encoder());
 
   return encode_scene->exec();
 }

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -7,22 +7,27 @@
 #include <gp/utils/utils.hpp>
 
 namespace streaming {
-Streamer::Streamer(const std::string &server_ip, const std::uint16_t server_port, std::shared_ptr<Encoder> encoder)
+Streamer::Streamer(const std::string &server_ip, const std::uint16_t server_port)
     : id_{std::string{STREAMER_ID} + ":" + gp::utils::generate_random_string(16u)}
-    , video_stream_info_{encoder->video_stream_info()} {
+    , connection_url_{std::string{"ws://"} + server_ip + ":" + std::to_string(server_port) + "/" + id_} {
   configuration_.iceServers.emplace_back("stun.l.google.com", 19302);
   configuration_.disableAutoNegotiation = true;
   configuration_.maxMessageSize = MAX_MESSAGE_SIZE;
 
   web_socket_ = std::make_shared<rtc::WebSocket>();
-  init_web_socket(web_socket_);
-  const auto url = std::string{"ws://"} + server_ip + ":" + std::to_string(server_port) + "/" + id_;
-  printf("Connection url: %s\n", url.c_str());
-  web_socket_->open(url);
+  printf("Connection url: %s\n", connection_url_.c_str());
+}
 
-  encoder->set_video_stream_callback([this](const std::byte *data, const std::size_t size, const bool eof) {
-    video_stream_callback(data, size, eof);
+void Streamer::start(std::shared_ptr<Encoder> encoder) {
+  video_stream_info_ = encoder->video_stream_info();
+  init_web_socket(web_socket_);
+  auto weak_self = weak_from_this();
+  encoder->set_video_stream_callback([weak_self](const std::byte *data, const std::size_t size, const bool eof) {
+    if (auto self = weak_self.lock()) {
+      self->video_stream_callback(data, size, eof);
+    }
   });
+  web_socket_->open(connection_url_);
 }
 
 void Streamer::set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback) {
@@ -30,19 +35,33 @@ void Streamer::set_event_callback(std::function<void(const gp::misc::Event &even
 }
 
 void Streamer::init_web_socket(std::shared_ptr<rtc::WebSocket> web_socket) {
-  auto on_web_socket_open_function = std::function<void()>{std::bind(&Streamer::on_web_socket_open, this)};
-  auto on_web_socket_closed_function = std::function<void()>{std::bind(&Streamer::on_web_socket_closed, this)};
-  auto on_web_socket_error_function =
-      std::function<void(std::string error)>{std::bind(&Streamer::on_web_socket_error, this, std::placeholders::_1)};
-  auto on_web_socket_binary_message_function = std::function<void(rtc::binary message)>{
-      std::bind(&Streamer::on_web_socket_binary_message, this, std::placeholders::_1)};
-  auto on_web_socket_string_message_function = std::function<void(std::string message)>{
-      std::bind(&Streamer::on_web_socket_string_message, this, std::placeholders::_1)};
-
-  web_socket->onOpen(on_web_socket_open_function);
-  web_socket->onClosed(on_web_socket_closed_function);
-  web_socket->onError(on_web_socket_error_function);
-  web_socket->onMessage(on_web_socket_binary_message_function, on_web_socket_string_message_function);
+  auto weak_self = weak_from_this();
+  web_socket->onOpen([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_web_socket_open();
+    }
+  });
+  web_socket->onClosed([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_web_socket_closed();
+    }
+  });
+  web_socket->onError([weak_self](std::string error) {
+    if (auto self = weak_self.lock()) {
+      self->on_web_socket_error(std::move(error));
+    }
+  });
+  web_socket->onMessage(
+      [weak_self](rtc::binary message) {
+        if (auto self = weak_self.lock()) {
+          self->on_web_socket_binary_message(std::move(message));
+        }
+      },
+      [weak_self](std::string message) {
+        if (auto self = weak_self.lock()) {
+          self->on_web_socket_string_message(std::move(message));
+        }
+      });
 }
 
 void Streamer::on_web_socket_open() {
@@ -63,34 +82,51 @@ void Streamer::on_web_socket_binary_message(rtc::binary /* message */) {
 }
 
 void Streamer::on_web_socket_string_message(std::string message) {
-  auto json = nlohmann::json::parse(message);
+  try {
+    auto json = nlohmann::json::parse(message);
 
-  if (json.contains("id") && json.contains("type") && json.contains("sdp")) {
-    std::string id = json.at("id");
-    std::string type = json.at("type");
-    std::string sdp = json.at("sdp");
+    if (json.contains("id") && json.contains("type") && json.contains("sdp")) {
+      std::string id = json.at("id");
+      std::string type = json.at("type");
+      std::string sdp = json.at("sdp");
 
-    if (type == "answer") {
-      if (peer_ && id == peer_->id) {
-        auto connection = peer_->connection;
-        auto description = rtc::Description{sdp, type};
-        connection->setRemoteDescription(description);
+      if (type == "answer") {
+        std::shared_ptr<Peer> peer;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          peer = peer_;
+        }
+        if (peer && id == peer->id) {
+          auto description = rtc::Description{sdp, type};
+          peer->connection->setRemoteDescription(description);
+        }
+        return;
+      }
+    } else if (json.contains("request_video_stream")) {
+      std::shared_ptr<Peer> existing_peer;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        existing_peer = peer_;
+      }
+      if (existing_peer) {
+        return;
+      }
+
+      std::string streamer = json.at("request_video_stream").at("streamer");
+      std::string receiver = json.at("request_video_stream").at("receiver");
+
+      auto new_peer = create_peer(receiver);
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        peer_ = new_peer;
       }
       return;
     }
-  } else if (json.contains("request_video_stream")) {
-    if (peer_) {
-      return;
-    }
 
-    std::string streamer = json.at("request_video_stream").at("streamer");
-    std::string receiver = json.at("request_video_stream").at("receiver");
-
-    peer_ = create_peer(receiver);
-    return;
+    printf("Unknown message: %s\n", message.c_str());
+  } catch (const std::exception &e) {
+    printf("Error processing message: %s\n", e.what());
   }
-
-  printf("Unknown message: %s\n", message.c_str());
 }
 
 void Streamer::on_data_channel_open() { printf("Data channel opened\n"); }
@@ -104,14 +140,18 @@ void Streamer::on_data_channel_binary_message(rtc::binary /* message */) {
 }
 
 void Streamer::on_data_channel_string_message(std::string message) {
-  auto json = nlohmann::json::parse(message);
+  try {
+    auto json = nlohmann::json::parse(message);
 
-  if (json.contains("event")) {
-    parse_event(json.at("event"));
-    return;
+    if (json.contains("event")) {
+      parse_event(json.at("event"));
+      return;
+    }
+
+    printf("Unknown message: %s\n", message.c_str());
+  } catch (const std::exception &e) {
+    printf("Error processing data channel message: %s\n", e.what());
   }
-
-  printf("Unknown message: %s\n", message.c_str());
 }
 
 void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
@@ -122,18 +162,24 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
   case rtc::PeerConnection::State::Connected:
     printf("Peer state: Connected\n");
     break;
-  case rtc::PeerConnection::State::Disconnected:
+  case rtc::PeerConnection::State::Disconnected: {
     printf("Peer state: Disconnected\n");
+    std::lock_guard<std::mutex> lock(mutex_);
     peer_ = nullptr;
     break;
-  case rtc::PeerConnection::State::Failed:
+  }
+  case rtc::PeerConnection::State::Failed: {
     printf("Peer state: Failed\n");
+    std::lock_guard<std::mutex> lock(mutex_);
     peer_ = nullptr;
     break;
-  case rtc::PeerConnection::State::Closed:
+  }
+  case rtc::PeerConnection::State::Closed: {
     printf("Peer state: Closed\n");
+    std::lock_guard<std::mutex> lock(mutex_);
     peer_ = nullptr;
     break;
+  }
 
   default:
     break;
@@ -142,9 +188,17 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
 
 void Streamer::on_peer_gathering_state_change(rtc::PeerConnection::GatheringState state) {
   if (state == rtc::PeerConnection::GatheringState::Complete) {
-    auto description = peer_->connection->localDescription();
+    std::shared_ptr<Peer> peer;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      peer = peer_;
+    }
+    if (!peer) {
+      return;
+    }
+    auto description = peer->connection->localDescription();
     const auto json = nlohmann::json{
-        {  "id",                        peer_->id},
+        {  "id",                         peer->id},
         {"type",        description->typeString()},
         { "sdp", std::string(description.value())}
     };
@@ -157,28 +211,46 @@ std::shared_ptr<Streamer::Peer> Streamer::create_peer(const std::string &id) {
   peer->id = id;
   peer->connection = std::make_shared<rtc::PeerConnection>(configuration_);
 
-  auto on_peer_state_change_function = std::function<void(rtc::PeerConnection::State state)>{
-      std::bind(&Streamer::on_peer_state_change, this, std::placeholders::_1)};
-  auto on_peer_gathering_state_change_function = std::function<void(rtc::PeerConnection::GatheringState state)>{
-      std::bind(&Streamer::on_peer_gathering_state_change, this, std::placeholders::_1)};
-  peer->connection->onStateChange(on_peer_state_change_function);
-  peer->connection->onGatheringStateChange(on_peer_gathering_state_change_function);
+  auto weak_self = weak_from_this();
+  peer->connection->onStateChange([weak_self](rtc::PeerConnection::State state) {
+    if (auto self = weak_self.lock()) {
+      self->on_peer_state_change(state);
+    }
+  });
+  peer->connection->onGatheringStateChange([weak_self](rtc::PeerConnection::GatheringState state) {
+    if (auto self = weak_self.lock()) {
+      self->on_peer_gathering_state_change(state);
+    }
+  });
 
   peer->data_channel = peer->connection->createDataChannel(DATA_CHANNEL_ID);
 
-  auto on_data_channel_open_function = std::function<void()>{std::bind(&Streamer::on_data_channel_open, this)};
-  auto on_data_channel_closed_function = std::function<void()>{std::bind(&Streamer::on_data_channel_closed, this)};
-  auto on_data_channel_error_function =
-      std::function<void(std::string error)>{std::bind(&Streamer::on_data_channel_error, this, std::placeholders::_1)};
-  auto on_data_channel_binary_message_function = std::function<void(rtc::binary message)>{
-      std::bind(&Streamer::on_data_channel_binary_message, this, std::placeholders::_1)};
-  auto on_data_channel_string_message_function = std::function<void(std::string message)>{
-      std::bind(&Streamer::on_data_channel_string_message, this, std::placeholders::_1)};
-
-  peer->data_channel->onOpen(on_data_channel_open_function);
-  peer->data_channel->onClosed(on_data_channel_closed_function);
-  peer->data_channel->onError(on_data_channel_error_function);
-  peer->data_channel->onMessage(on_data_channel_binary_message_function, on_data_channel_string_message_function);
+  peer->data_channel->onOpen([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_data_channel_open();
+    }
+  });
+  peer->data_channel->onClosed([weak_self]() {
+    if (auto self = weak_self.lock()) {
+      self->on_data_channel_closed();
+    }
+  });
+  peer->data_channel->onError([weak_self](std::string error) {
+    if (auto self = weak_self.lock()) {
+      self->on_data_channel_error(std::move(error));
+    }
+  });
+  peer->data_channel->onMessage(
+      [weak_self](rtc::binary message) {
+        if (auto self = weak_self.lock()) {
+          self->on_data_channel_binary_message(std::move(message));
+        }
+      },
+      [weak_self](std::string message) {
+        if (auto self = weak_self.lock()) {
+          self->on_data_channel_string_message(std::move(message));
+        }
+      });
 
   peer->connection->setLocalDescription();
 
@@ -204,12 +276,17 @@ void Streamer::send_video_stream_info() {
 }
 
 void Streamer::video_stream_callback(const std::byte *data, const std::size_t size, const bool eof) {
-  if (peer_ && peer_->data_channel && peer_->data_channel->isOpen()) {
-    peer_->data_channel->send(data, size);
+  std::shared_ptr<Peer> peer;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    peer = peer_;
+  }
+  if (peer && peer->data_channel && peer->data_channel->isOpen()) {
+    peer->data_channel->send(data, size);
     if (eof) {
       constexpr auto eof_data = "EOF";
       constexpr auto eof_size = 4u;
-      peer_->data_channel->send(reinterpret_cast<const std::byte *>(eof_data), eof_size);
+      peer->data_channel->send(reinterpret_cast<const std::byte *>(eof_data), eof_size);
     }
   }
 }

--- a/streaming/streaming_streamer/streamer.hpp
+++ b/streaming/streaming_streamer/streamer.hpp
@@ -8,19 +8,23 @@
 #include <nlohmann/json.hpp>
 #include <rtc/rtc.hpp>
 
+#include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <string>
 
 namespace streaming {
-class Streamer {
+class Streamer : public std::enable_shared_from_this<Streamer> {
 public:
   Streamer(const Streamer &) = delete;
   Streamer &operator=(const Streamer &) = delete;
   Streamer(Streamer &&other) noexcept = delete;
   Streamer &operator=(Streamer &&other) noexcept = delete;
 
-  Streamer(const std::string &server_ip, const std::uint16_t server_port, std::shared_ptr<Encoder> encoder);
+  Streamer(const std::string &server_ip, const std::uint16_t server_port);
 
+  void start(std::shared_ptr<Encoder> encoder);
   void set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback);
 
 private:
@@ -53,11 +57,13 @@ private:
   void parse_event(const nlohmann::json &json_event);
 
   const std::string id_{};
-  const VideoStreamInfo video_stream_info_{};
-  bool connection_open_{false};
+  std::string connection_url_{};
+  VideoStreamInfo video_stream_info_{};
+  std::atomic<bool> connection_open_{false};
   rtc::Configuration configuration_{};
   std::shared_ptr<rtc::WebSocket> web_socket_{};
   std::shared_ptr<Peer> peer_{};
+  mutable std::mutex mutex_{};
   std::function<void(const gp::misc::Event &event)> event_callback_{};
 };
 } // namespace streaming


### PR DESCRIPTION
Closes #131
Closes #132
Closes #133
Closes #134

Addresses four related issues in the streaming module:

**#132 - Data races on shared state:**
- connection_open_ made std::atomic<bool> in Receiver and Streamer
- peer_, streamer_infos_ protected by std::mutex in Receiver and Streamer
- clients_, streamers_, receivers_, temporary_store_ protected by std::mutex in Server

**#131 - Raw this capture in callbacks:**
- Receiver and Streamer inherit from std::enable_shared_from_this<T>
- init_web_socket() moved from Receiver constructor to connect()
- Streamer gains a start(encoder) method; callback setup moved there from constructor
- All std::bind callbacks replaced with weak_from_this() lambda captures
- main.cpp files updated to use make_shared and call start() where needed

**#133 - JSON without error handling:**
- All nlohmann::json::parse() and field accesses wrapped in try/catch(const std::exception &)

**#134 - Null dereference after weak_ptr::lock():**
- Null checks added after every weak_ptr<Client>::lock() in server.cpp
- if (!self) guard inside every weak_from_this() lambda in Receiver and Streamer
