### PR TITLE
147: Fix on_segment() geometry bug: std::max -> std::min for lower bounds

### DIFF
--- a/gp/math/math.cpp
+++ b/gp/math/math.cpp
@@ -16,8 +16,8 @@ float orientation(float p_x, float p_y, float q_x, float q_y, float r_x, float r
 }
 
 bool on_segment(float p_x, float p_y, float q_x, float q_y, float r_x, float r_y) {
-  return q_x <= std::max(p_x, r_x) && q_x >= std::max(p_x, r_x) && q_y <= std::max(p_y, r_y) &&
-         q_y >= std::max(p_y, r_y);
+  return q_x <= std::max(p_x, r_x) && q_x >= std::min(p_x, r_x) && q_y <= std::max(p_y, r_y) &&
+         q_y >= std::min(p_y, r_y);
 }
 } // namespace
 


### PR DESCRIPTION
Fixes the `on_segment()` function in `gp/math/math.cpp` where both lower-bound comparisons used `std::max` instead of `std::min`, causing incorrect results for segments with decreasing coordinates.

Closes #147