### PR TITLE
146, 149: Fix utils bugs: load_txt_file silent failure and split_by wrong substr

### DIFF
--- a/gp/utils/utils.cpp
+++ b/gp/utils/utils.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <random>
 #include <sstream>
+#include <stdexcept>
 
 #ifdef __APPLE__
 # include <libgen.h>
@@ -16,10 +17,10 @@ std::vector<std::string> split_by(const std::string &src, const std::string &del
   auto pos = std::string::npos;
   auto ppos = std::size_t{0u};
   while ((pos = src.find(delimiter, ppos)) != std::string::npos) {
-    tokens.emplace_back(src.substr(ppos, pos));
-    ppos += tokens.back().length() + 1;
+    tokens.emplace_back(src.substr(ppos, pos - ppos));
+    ppos += tokens.back().length() + delimiter.length();
   }
-  tokens.emplace_back(src.substr(ppos, src.length() - 1));
+  tokens.emplace_back(src.substr(ppos));
   return tokens;
 }
 
@@ -41,6 +42,9 @@ std::string generate_random_string(const std::size_t length) {
 
 std::string load_txt_file(const std::string &filename) {
   auto txt_file = std::ifstream{filename};
+  if (!txt_file.is_open()) {
+    throw std::runtime_error{"Could not open file: " + filename};
+  }
   auto buffer = std::stringstream{};
   buffer << txt_file.rdbuf();
   return buffer.str();

--- a/gp/utils/utils.cpp
+++ b/gp/utils/utils.cpp
@@ -13,6 +13,9 @@
 
 namespace gp::utils {
 std::vector<std::string> split_by(const std::string &src, const std::string &delimiter) {
+  if (delimiter.empty()) {
+    throw std::invalid_argument{"split_by: delimiter must not be empty"};
+  }
   auto tokens = std::vector<std::string>{};
   auto pos = std::string::npos;
   auto ppos = std::size_t{0u};


### PR DESCRIPTION
Two bug fixes in `gp/utils/utils.cpp`:

**#146 — load_txt_file silent failure**: Added `is_open()` check after opening the file; throws `std::runtime_error` with the filename when the file cannot be opened.

**#149 — split_by wrong substr**: `substr(ppos, pos)` used `pos` as a length (it's an absolute index); fixed to `substr(ppos, pos - ppos)`. Final token `substr(ppos, src.length() - 1)` dropped the last character; fixed to `substr(ppos)`. Also fixed `ppos` advance to use `delimiter.length()` instead of hardcoded `1`.

Closes #146
Closes #149