### PR TITLE
148, 150, 151, 152: Fix bounds/safety issues in AI and Wolf modules

### DIFF
--- a/ai/ai_common/neural_network.cpp
+++ b/ai/ai_common/neural_network.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <random>
+#include <stdexcept>
 
 namespace ai {
 namespace {
@@ -42,7 +43,12 @@ void NeuralNetwork::init_random(const float mid, const float spread) {
   }
 }
 
-void NeuralNetwork::set_input(const std::size_t index, const float value) { inputs_[index] = value; }
+void NeuralNetwork::set_input(const std::size_t index, const float value) {
+  if (index >= inputs_.size()) {
+    throw std::out_of_range{"NeuralNetwork::set_input: index out of range"};
+  }
+  inputs_[index] = value;
+}
 
 const std::vector<float> &NeuralNetwork::get_output() const { return activations_.back(); }
 

--- a/wolf/wolf_common/raw_map.cpp
+++ b/wolf/wolf_common/raw_map.cpp
@@ -27,8 +27,7 @@ std::uint16_t &RawMap::BlockType::operator[](const std::size_t index) {
   if (index == 2u) {
     return reinterpret_cast<std::underlying_type<Map::Extra>::type &>(extra);
   }
-  static auto dump = std::uint16_t{};
-  return dump;
+  throw std::out_of_range{"RawMap::BlockType::operator[]: index " + std::to_string(index) + " out of range"};
 }
 
 RawMap::RawMap(const int width, const int height, std::vector<BlockType> &&blocks)

--- a/wolf/wolf_common/raw_map.cpp
+++ b/wolf/wolf_common/raw_map.cpp
@@ -1,6 +1,7 @@
 #include "raw_map.hpp"
 
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 
 namespace wolf {

--- a/wolf/wolf_common/wolf_scene.cpp
+++ b/wolf/wolf_common/wolf_scene.cpp
@@ -3,6 +3,7 @@
 #include <glm/glm.hpp>
 
 #include <cmath>
+#include <stdexcept>
 
 namespace wolf {
 WolfScene::WolfScene(std::unique_ptr<const RawMap> raw_map,
@@ -13,6 +14,9 @@ WolfScene::WolfScene(std::unique_ptr<const RawMap> raw_map,
     , last_timestamp_ms_{timestamp()}
     , walls_(number_of_rays)
     , ray_rots_(number_of_rays) {
+  if (number_of_rays == 0u) {
+    throw std::invalid_argument{"WolfScene: number_of_rays must be greater than 0"};
+  }
   const auto fov_in_rad = glm::radians(static_cast<float>(fov_in_degrees));
 
   const auto fov_step = fov_in_rad / (ray_rots_.size() - 1u);

--- a/wolf/wolf_common/wolf_scene.cpp
+++ b/wolf/wolf_common/wolf_scene.cpp
@@ -14,8 +14,8 @@ WolfScene::WolfScene(std::unique_ptr<const RawMap> raw_map,
     , last_timestamp_ms_{timestamp()}
     , walls_(number_of_rays)
     , ray_rots_(number_of_rays) {
-  if (number_of_rays == 0u) {
-    throw std::invalid_argument{"WolfScene: number_of_rays must be greater than 0"};
+  if (number_of_rays < 2u) {
+    throw std::invalid_argument{"WolfScene: number_of_rays must be at least 2"};
   }
   const auto fov_in_rad = glm::radians(static_cast<float>(fov_in_degrees));
 

--- a/wolf/wolf_sprite_voxelizer/voxel_scene.cpp
+++ b/wolf/wolf_sprite_voxelizer/voxel_scene.cpp
@@ -127,11 +127,11 @@ void VoxelScene::voxelize_sprite() {
   // sprite_index_ += 8;
   // sprite_voxelizer_->voxelize(index, index + 4, index + 2, index + 6);
   sprite_voxelizer_->voxelize(sprite_index_++, true);
-  vipe_data();
+  wipe_data();
   upload_data();
 }
 
-void VoxelScene::vipe_data() {
+void VoxelScene::wipe_data() {
   vao_.reset();
   vertex_buffer_.reset();
   index_buffer_.reset();

--- a/wolf/wolf_sprite_voxelizer/voxel_scene.hpp
+++ b/wolf/wolf_sprite_voxelizer/voxel_scene.hpp
@@ -30,7 +30,7 @@ private:
   void redraw();
 
   void voxelize_sprite();
-  void vipe_data();
+  void wipe_data();
   void upload_data();
 
   std::shared_ptr<SpriteVoxelizer> sprite_voxelizer_{};


### PR DESCRIPTION
Four small fixes:

**#148 — NeuralNetwork::set_input() bounds check**: Added `out_of_range` guard before accessing `inputs_[index]`.

**#150 — RawMap::BlockType::operator[] mutable static**: Replaced the returning-a-static-variable fallback with `throw std::out_of_range` to prevent silent out-of-bounds writes.

**#151 — WolfScene zero rays guard**: Added `invalid_argument` throw when `number_of_rays == 0` to prevent unsigned underflow in the `fov_step` calculation.

**#152 — VoxelScene vipe_data typo**: Renamed `vipe_data()` → `wipe_data()` in declaration, definition, and call site.

Closes #148
Closes #150
Closes #151
Closes #152