### PR TITLE
154, 156: Fix loaders_assimp: throw on load failure and refactor orientation lookup

### DIFF
--- a/loaders/loaders_assimp/model.cpp
+++ b/loaders/loaders_assimp/model.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <iterator>
 #include <span>
+#include <stdexcept>
 
 namespace {
 glm::mat4 to_glm(const aiMatrix4x4 &mat) {
@@ -38,7 +39,7 @@ Model::Model(const std::string &filename) {
   const auto scene =
       importer.ReadFile(filename, aiPostProcessSteps::aiProcess_Triangulate | aiPostProcessSteps::aiProcess_GenNormals);
   if (!scene) {
-    return;
+    throw std::runtime_error{"Assimp failed to load '" + filename + "': " + importer.GetErrorString()};
   }
 
   const auto model_format = get_model_format(importer);

--- a/loaders/loaders_assimp/model_orientation.cpp
+++ b/loaders/loaders_assimp/model_orientation.cpp
@@ -1,5 +1,7 @@
 #include "model_orientation.hpp"
 
+#include <unordered_map>
+
 namespace {
 bool operator==(const Orientation &lhs, const Orientation &rhs) { return lhs.up == rhs.up && lhs.front == rhs.front; }
 
@@ -76,77 +78,39 @@ Orientation get_orientation(const ModelFormat model_format, const aiMetadata *co
 }
 
 glm::mat4 get_orientation_matrix(const Orientation &orientation) {
-  if (orientation == Orientation{} /* Axis::y_plus, Axis::z_minus */) {
-    return glm::mat4(1.0);
+  // Encode {up, front} as a single integer key: up * 6 + front.
+  // Axis enum order: x_minus=0, y_minus=1, z_minus=2, x_plus=3, y_plus=4, z_plus=5
+  const auto key = [](const Orientation &o) { return static_cast<int>(o.up) * 6 + static_cast<int>(o.front); };
+  static const std::unordered_map<int, glm::mat4> table = {
+      { key({Axis::y_plus, Axis::z_minus}),                                     glm::mat4(1.0f)},
+      { key({Axis::y_minus, Axis::z_plus}),  {1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1}},
+      {  key({Axis::y_plus, Axis::z_plus}),  {-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1}},
+      {key({Axis::y_minus, Axis::z_minus}),  {-1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}},
+      { key({Axis::z_minus, Axis::y_plus}), {-1, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 1}},
+      { key({Axis::z_plus, Axis::y_minus}),   {-1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1}},
+      {key({Axis::z_minus, Axis::y_minus}),   {1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1}},
+      {  key({Axis::z_plus, Axis::y_plus}),   {1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1}},
+      { key({Axis::z_plus, Axis::x_minus}),    {0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1}},
+      { key({Axis::z_minus, Axis::x_plus}),  {0, 0, -1, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1}},
+      {  key({Axis::z_plus, Axis::x_plus}),  {0, 0, -1, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1}},
+      {key({Axis::z_minus, Axis::x_minus}),  {0, 0, 1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1}},
+      { key({Axis::x_minus, Axis::z_plus}), {0, -1, 0, 0, -1, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1}},
+      { key({Axis::x_plus, Axis::z_minus}),   {0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}},
+      {key({Axis::x_minus, Axis::z_minus}),   {0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}},
+      {  key({Axis::x_plus, Axis::z_plus}),   {0, 1, 0, 0, 1, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1}},
+      { key({Axis::x_plus, Axis::y_minus}),    {0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1}},
+      { key({Axis::x_minus, Axis::y_plus}),  {0, -1, 0, 0, 0, 0, -1, 0, 1, 0, 0, 0, 0, 0, 0, 1}},
+      {  key({Axis::x_plus, Axis::y_plus}),  {0, 1, 0, 0, 0, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 1}},
+      {key({Axis::x_minus, Axis::y_minus}),  {0, -1, 0, 0, 0, 0, 1, 0, -1, 0, 0, 0, 0, 0, 0, 1}},
+      { key({Axis::y_minus, Axis::x_plus}), {0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 1}},
+      { key({Axis::y_plus, Axis::x_minus}),   {0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 1}},
+      {key({Axis::y_minus, Axis::x_minus}),   {0, 0, 1, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1}},
+      {  key({Axis::y_plus, Axis::x_plus}),   {0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1}},
+  };
+
+  const auto it = table.find(key(orientation));
+  if (it != table.end()) {
+    return it->second;
   }
-  if (orientation == Orientation{Axis::y_minus, Axis::z_plus}) {
-    return {1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::y_plus, Axis::z_plus}) {
-    return {-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::y_minus, Axis::z_minus}) {
-    return {-1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_minus, Axis::y_plus}) {
-    return {-1, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_plus, Axis::y_minus}) {
-    return {-1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_minus, Axis::y_minus}) {
-    return {1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_plus, Axis::y_plus}) {
-    return {1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_plus, Axis::x_minus}) {
-    return {0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_minus, Axis::x_plus}) {
-    return {0, 0, -1, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_plus, Axis::x_plus}) {
-    return {0, 0, -1, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::z_minus, Axis::x_minus}) {
-    return {0, 0, 1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_minus, Axis::z_plus}) {
-    return {0, -1, 0, 0, -1, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_plus, Axis::z_minus}) {
-    return {0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_minus, Axis::z_minus}) {
-    return {0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_plus, Axis::z_plus}) {
-    return {0, 1, 0, 0, 1, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_plus, Axis::y_minus}) {
-    return {0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_minus, Axis::y_plus}) {
-    return {0, -1, 0, 0, 0, 0, -1, 0, 1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_plus, Axis::y_plus}) {
-    return {0, 1, 0, 0, 0, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::x_minus, Axis::y_minus}) {
-    return {0, -1, 0, 0, 0, 0, 1, 0, -1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::y_minus, Axis::x_plus}) {
-    return {0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::y_plus, Axis::x_minus}) {
-    return {0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::y_minus, Axis::x_minus}) {
-    return {0, 0, 1, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  if (orientation == Orientation{Axis::y_plus, Axis::x_plus}) {
-    return {0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1};
-  }
-  return glm::mat4(1.0);
+  return glm::mat4(1.0f);
 }

--- a/loaders/loaders_assimp/model_orientation.cpp
+++ b/loaders/loaders_assimp/model_orientation.cpp
@@ -3,8 +3,6 @@
 #include <unordered_map>
 
 namespace {
-bool operator==(const Orientation &lhs, const Orientation &rhs) { return lhs.up == rhs.up && lhs.front == rhs.front; }
-
 Axis to_axis(const std::int32_t data_axis, const std::int32_t data_sign) {
   if (data_sign == -1) {
     if (data_axis == 0) {

--- a/loaders/loaders_assimp/model_orientation.cpp
+++ b/loaders/loaders_assimp/model_orientation.cpp
@@ -77,7 +77,6 @@ Orientation get_orientation(const ModelFormat model_format, const aiMetadata *co
 
 glm::mat4 get_orientation_matrix(const Orientation &orientation) {
   // Encode {up, front} as a single integer key: up * 6 + front.
-  // Axis enum order: x_minus=0, y_minus=1, z_minus=2, x_plus=3, y_plus=4, z_plus=5
   const auto key = [](const Orientation &o) { return static_cast<int>(o.up) * 6 + static_cast<int>(o.front); };
   static const std::unordered_map<int, glm::mat4> table = {
       { key({Axis::y_plus, Axis::z_minus}),                                     glm::mat4(1.0f)},

--- a/loaders/loaders_assimp/model_orientation.hpp
+++ b/loaders/loaders_assimp/model_orientation.hpp
@@ -6,12 +6,12 @@
 #include <glm/glm.hpp>
 
 enum class Axis {
-  x_minus,
-  y_minus,
-  z_minus,
-  x_plus,
-  y_plus,
-  z_plus
+  x_minus = 0,
+  y_minus = 1,
+  z_minus = 2,
+  x_plus = 3,
+  y_plus = 4,
+  z_plus = 5
 };
 
 struct Orientation {


### PR DESCRIPTION
Two improvements to `loaders/loaders_assimp`:

**#154 — Throw on load failure**: `Model` constructor now throws `std::runtime_error` (with Assimp error string) when `ReadFile()` fails, instead of silently returning a partially-constructed object.

**#156 — Orientation lookup table**: Replaced the 24-branch if-chain in `get_orientation_matrix()` with a `static const std::unordered_map<int, glm::mat4>` keyed on `up * 6 + front`. Unknown orientations still fall back to the identity matrix.

Closes #154
Closes #156