### PR TITLE
153, 155: Add namespace loaders and isolate CGLTF_IMPLEMENTATION

### DIFF
--- a/loaders/loaders_assimp/main.cpp
+++ b/loaders/loaders_assimp/main.cpp
@@ -45,8 +45,8 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  auto model = std::make_shared<const Model>(program_setup.filename);
-  auto model_scene = std::make_unique<ModelScene>(model);
+  auto model = std::make_shared<const loaders::Model>(program_setup.filename);
+  auto model_scene = std::make_unique<loaders::ModelScene>(model);
   model_scene->init(program_setup.width, program_setup.height, "loaders_assimp");
   return model_scene->exec();
 }

--- a/loaders/loaders_assimp/model.cpp
+++ b/loaders/loaders_assimp/model.cpp
@@ -33,6 +33,7 @@ glm::mat4 to_glm(const aiMatrix4x4 &mat) {
 }
 } // namespace
 
+namespace loaders {
 Model::Model(const std::string &filename) {
   auto importer = Assimp::Importer();
   const auto scene =
@@ -137,3 +138,5 @@ void Model::process_mesh(const aiMesh *const mesh, const glm::mat4 &transformati
   }
   indices_.emplace_back(std::move(indices));
 }
+
+} // namespace loaders

--- a/loaders/loaders_assimp/model.hpp
+++ b/loaders/loaders_assimp/model.hpp
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <vector>
 
+namespace loaders {
 class Model {
 public:
   Model(const Model &) = delete;
@@ -34,3 +35,4 @@ private:
   std::vector<std::vector<std::uint32_t>> indices_{};
   std::vector<glm::vec4> colors_{};
 };
+} // namespace loaders

--- a/loaders/loaders_assimp/model_scene.cpp
+++ b/loaders/loaders_assimp/model_scene.cpp
@@ -5,6 +5,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+namespace loaders {
 ModelScene::ModelScene(std::shared_ptr<const Model> model)
     : model_{std::move(model)} {}
 
@@ -155,3 +156,4 @@ void ModelScene::upload_data() {
     sizes_.emplace_back(static_cast<GLsizei>(indices.size()));
   }
 }
+} // namespace loaders

--- a/loaders/loaders_assimp/model_scene.hpp
+++ b/loaders/loaders_assimp/model_scene.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <memory>
 
+namespace loaders {
 class ModelScene : public gp::sdl::Scene3D {
 public:
   explicit ModelScene(std::shared_ptr<const Model> model);
@@ -48,3 +49,4 @@ private:
 
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
 };
+} // namespace loaders

--- a/loaders/loaders_cgltf/cgltf_impl.cpp
+++ b/loaders/loaders_cgltf/cgltf_impl.cpp
@@ -1,0 +1,2 @@
+#define CGLTF_IMPLEMENTATION
+#include <cgltf.h>

--- a/loaders/loaders_cgltf/main.cpp
+++ b/loaders/loaders_cgltf/main.cpp
@@ -45,8 +45,8 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  auto model = std::make_shared<const Model>(program_setup.filename);
-  auto model_scene = std::make_unique<ModelScene>(model);
+  auto model = std::make_shared<const loaders::Model>(program_setup.filename);
+  auto model_scene = std::make_unique<loaders::ModelScene>(model);
   model_scene->init(program_setup.width, program_setup.height, "loaders_cgltf");
   return model_scene->exec();
 }

--- a/loaders/loaders_cgltf/model.cpp
+++ b/loaders/loaders_cgltf/model.cpp
@@ -3,12 +3,12 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 
-#define CGLTF_IMPLEMENTATION
 #include <cgltf.h>
 
 #include <span>
 #include <stdexcept>
 
+namespace loaders {
 namespace {
 glm::mat4 to_glm(const cgltf_float mat[16]) {
   return {mat[0],
@@ -138,3 +138,5 @@ void Model::process_mesh(const cgltf_mesh *const mesh, const glm::mat4 &transfor
     colors_.emplace_back(0.75f, 0.75f, 0.75f, 1.0f);
   }
 }
+
+} // namespace loaders

--- a/loaders/loaders_cgltf/model.hpp
+++ b/loaders/loaders_cgltf/model.hpp
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <vector>
 
+namespace loaders {
 class Model {
 public:
   Model(const Model &) = delete;
@@ -35,3 +36,4 @@ private:
   std::vector<glm::vec4> colors_{};
   std::set<std::string> meshes_{};
 };
+} // namespace loaders

--- a/loaders/loaders_cgltf/model_scene.cpp
+++ b/loaders/loaders_cgltf/model_scene.cpp
@@ -5,6 +5,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+namespace loaders {
 ModelScene::ModelScene(std::shared_ptr<const Model> model)
     : model_{model} {}
 
@@ -156,3 +157,4 @@ void ModelScene::upload_data() {
     sizes_.emplace_back(static_cast<GLsizei>(indices.size()));
   }
 }
+} // namespace loaders

--- a/loaders/loaders_cgltf/model_scene.hpp
+++ b/loaders/loaders_cgltf/model_scene.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <memory>
 
+namespace loaders {
 class ModelScene : public gp::sdl::Scene3D {
 public:
   explicit ModelScene(std::shared_ptr<const Model> model);
@@ -48,3 +49,4 @@ private:
 
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
 };
+} // namespace loaders


### PR DESCRIPTION
Two improvements to loader modules:

**#153 — Add namespace loaders**: Wrapped `Model` and `ModelScene` classes in `namespace loaders` for both `loaders_assimp` and `loaders_cgltf`. Updated `main.cpp` files to use `loaders::Model` and `loaders::ModelScene`. This prevents symbol collisions and matches the convention used by other modules (`ai`, `streaming`, `wolf`).

**#155 — Isolate CGLTF_IMPLEMENTATION**: Moved the `#define CGLTF_IMPLEMENTATION` from `model.cpp` to a new dedicated `cgltf_impl.cpp` translation unit. This prevents ODR violations if `cgltf.h` is ever included in multiple translation units.

Closes #153
Closes #155