### PR TITLE
157: Add RAII wrappers for FFmpeg types

### DIFF
--- a/gp/ffmpeg/ffmpeg.hpp
+++ b/gp/ffmpeg/ffmpeg.hpp
@@ -7,3 +7,55 @@ extern "C" {
 #include <libavutil/opt.h>
 #include <libswscale/swscale.h>
 }
+
+#include <memory>
+
+namespace gp::ffmpeg {
+// Custom deleters for FFmpeg RAII wrappers
+struct AVCodecContextDeleter {
+  void operator()(AVCodecContext *ctx) const {
+    if (ctx) {
+      avcodec_free_context(&ctx);
+    }
+  }
+};
+
+struct AVCodecParserContextDeleter {
+  void operator()(AVCodecParserContext *parser) const {
+    if (parser) {
+      av_parser_close(parser);
+    }
+  }
+};
+
+struct AVPacketDeleter {
+  void operator()(AVPacket *packet) const {
+    if (packet) {
+      av_packet_free(&packet);
+    }
+  }
+};
+
+struct AVFrameDeleter {
+  void operator()(AVFrame *frame) const {
+    if (frame) {
+      av_frame_free(&frame);
+    }
+  }
+};
+
+struct SwsContextDeleter {
+  void operator()(SwsContext *ctx) const {
+    if (ctx) {
+      sws_freeContext(ctx);
+    }
+  }
+};
+
+// RAII unique_ptr aliases
+using UniqueAVCodecContext = std::unique_ptr<AVCodecContext, AVCodecContextDeleter>;
+using UniqueAVCodecParserContext = std::unique_ptr<AVCodecParserContext, AVCodecParserContextDeleter>;
+using UniqueAVPacket = std::unique_ptr<AVPacket, AVPacketDeleter>;
+using UniqueAVFrame = std::unique_ptr<AVFrame, AVFrameDeleter>;
+using UniqueSwsContext = std::unique_ptr<SwsContext, SwsContextDeleter>;
+} // namespace gp::ffmpeg

--- a/gp/ffmpeg/ffmpeg.hpp
+++ b/gp/ffmpeg/ffmpeg.hpp
@@ -13,7 +13,7 @@ extern "C" {
 namespace gp::ffmpeg {
 // Custom deleters for FFmpeg RAII wrappers
 struct AVCodecContextDeleter {
-  void operator()(AVCodecContext *ctx) const {
+  void operator()(AVCodecContext *ctx) const noexcept {
     if (ctx) {
       avcodec_free_context(&ctx);
     }
@@ -21,7 +21,7 @@ struct AVCodecContextDeleter {
 };
 
 struct AVCodecParserContextDeleter {
-  void operator()(AVCodecParserContext *parser) const {
+  void operator()(AVCodecParserContext *parser) const noexcept {
     if (parser) {
       av_parser_close(parser);
     }
@@ -29,7 +29,7 @@ struct AVCodecParserContextDeleter {
 };
 
 struct AVPacketDeleter {
-  void operator()(AVPacket *packet) const {
+  void operator()(AVPacket *packet) const noexcept {
     if (packet) {
       av_packet_free(&packet);
     }
@@ -37,7 +37,7 @@ struct AVPacketDeleter {
 };
 
 struct AVFrameDeleter {
-  void operator()(AVFrame *frame) const {
+  void operator()(AVFrame *frame) const noexcept {
     if (frame) {
       av_frame_free(&frame);
     }
@@ -45,7 +45,7 @@ struct AVFrameDeleter {
 };
 
 struct SwsContextDeleter {
-  void operator()(SwsContext *ctx) const {
+  void operator()(SwsContext *ctx) const noexcept {
     if (ctx) {
       sws_freeContext(ctx);
     }


### PR DESCRIPTION
Adds FFmpeg RAII wrapper types to `gp/ffmpeg/ffmpeg.hpp`:

- `UniqueAVCodecContext` (deleter: `avcodec_free_context`)
- `UniqueAVCodecParserContext` (deleter: `av_parser_close`)
- `UniqueAVPacket` (deleter: `av_packet_free`)
- `UniqueAVFrame` (deleter: `av_frame_free`)
- `UniqueSwsContext` (deleter: `sws_freeContext`)

These are defined as `unique_ptr` aliases in `namespace gp::ffmpeg` and eliminate the need for manual `destroy()` methods in Encoder and Decoder, making exception safety automatic.

Closes #157