### PR TITLE
158: Encoder RAII - replace raw FFmpeg pointers with UniquePtr wrappers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks: 'clang-diagnostic-*,clang-analyzer-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle: file
 User: 'Marek Kijo<marekkijo@gmail.com>'
 CheckOptions:

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -73,7 +73,9 @@ Encoder::Encoder(const VideoStreamInfo &video_stream_info)
 
 Encoder::~Encoder() {
   if (context_) {
-    encode_frame(nullptr);
+    try {
+      encode_frame(nullptr);
+    } catch (...) {}
   }
 }
 

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -14,15 +14,12 @@ Encoder::Encoder(const VideoStreamInfo &video_stream_info)
     , context_{codec_ ? avcodec_alloc_context3(codec_) : nullptr}
     , packet_{av_packet_alloc()} {
   if (codec_ == nullptr) {
-    destroy();
     throw std::runtime_error{"avcodec_find_encoder failed"};
   }
-  if (context_ == nullptr) {
-    destroy();
+  if (!context_) {
     throw std::runtime_error{"avcodec_alloc_context3 failed"};
   }
-  if (packet_ == nullptr) {
-    destroy();
+  if (!packet_) {
     throw std::runtime_error{"av_packet_alloc failed"};
   }
 
@@ -41,14 +38,12 @@ Encoder::Encoder(const VideoStreamInfo &video_stream_info)
     av_opt_set(context_->priv_data, "tune", "zerolatency", 0);
   }
 
-  if (avcodec_open2(context_, codec_, nullptr) < 0) {
-    destroy();
+  if (avcodec_open2(context_.get(), codec_, nullptr) < 0) {
     throw std::runtime_error{"avcodec_open2 failed"};
   }
 
-  frame_ = av_frame_alloc();
-  if (frame_ == nullptr) {
-    destroy();
+  frame_.reset(av_frame_alloc());
+  if (!frame_) {
     throw std::runtime_error{"av_frame_alloc failed"};
   }
 
@@ -57,23 +52,21 @@ Encoder::Encoder(const VideoStreamInfo &video_stream_info)
   frame_->height = context_->height;
   frame_->pts = 0;
 
-  if (av_frame_get_buffer(frame_, 0) < 0) {
-    destroy();
+  if (av_frame_get_buffer(frame_.get(), 0) < 0) {
     throw std::runtime_error{"av_frame_get_buffer failed"};
   }
 
-  sws_context_ = sws_getContext(context_->width,
-                                context_->height,
-                                AV_PIX_FMT_RGB32,
-                                context_->width,
-                                context_->height,
-                                AV_PIX_FMT_YUV420P,
-                                SWS_BILINEAR,
-                                nullptr,
-                                nullptr,
-                                nullptr);
-  if (sws_context_ == nullptr) {
-    destroy();
+  sws_context_.reset(sws_getContext(context_->width,
+                                    context_->height,
+                                    AV_PIX_FMT_RGB32,
+                                    context_->width,
+                                    context_->height,
+                                    AV_PIX_FMT_YUV420P,
+                                    SWS_BILINEAR,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr));
+  if (!sws_context_) {
     throw std::runtime_error{"sws_getContext failed"};
   }
 }
@@ -82,8 +75,6 @@ Encoder::~Encoder() {
   if (context_) {
     encode_frame(nullptr);
   }
-
-  destroy();
 }
 
 std::shared_ptr<FrameData> Encoder::video_frame() { return video_frame_; }
@@ -102,7 +93,7 @@ void Encoder::set_video_stream_callback(
 }
 
 void Encoder::encode() {
-  if (av_frame_make_writable(frame_) < 0) {
+  if (av_frame_make_writable(frame_.get()) < 0) {
     throw std::runtime_error{"av_frame_make_writable failed"};
   }
 
@@ -116,7 +107,7 @@ void Encoder::encode() {
 
 void Encoder::encode_frame(AVFrame *frame) {
   for (;;) {
-    const auto send_result = avcodec_send_frame(context_, frame);
+    const auto send_result = avcodec_send_frame(context_.get(), frame);
     if (send_result == AVERROR_EOF) {
       return;
     }
@@ -128,7 +119,7 @@ void Encoder::encode_frame(AVFrame *frame) {
 
     bool drained = false;
     while (!drained) {
-      const auto rc = avcodec_receive_packet(context_, packet_);
+      const auto rc = avcodec_receive_packet(context_.get(), packet_.get());
       if (rc == AVERROR(EAGAIN)) {
         drained = true;
       } else if (rc == AVERROR_EOF) {
@@ -136,7 +127,7 @@ void Encoder::encode_frame(AVFrame *frame) {
           static constexpr std::array<uint8_t, 4> endcode{0, 0, 1, 0xb7};
           video_stream_callback_(reinterpret_cast<const std::byte *>(endcode.data()), sizeof(endcode), true);
         }
-        av_packet_unref(packet_);
+        av_packet_unref(packet_.get());
         return;
       } else if (rc < 0) {
         char errbuf[AV_ERROR_MAX_STRING_SIZE]{};
@@ -148,7 +139,7 @@ void Encoder::encode_frame(AVFrame *frame) {
                                  static_cast<std::size_t>(packet_->size),
                                  false);
         }
-        av_packet_unref(packet_);
+        av_packet_unref(packet_.get());
       }
     }
 
@@ -176,26 +167,13 @@ void Encoder::rgb_to_yuv() {
   const std::array<int, 1> in_linesize{CHANNELS_NUM * context_->width};
 
   auto rgb_frame_data = reinterpret_cast<std::uint8_t *>(rgb_frame_.data());
-  sws_scale(sws_context_, &rgb_frame_data, in_linesize.data(), 0, context_->height, frame_->data, frame_->linesize);
+  sws_scale(sws_context_.get(),
+            &rgb_frame_data,
+            in_linesize.data(),
+            0,
+            context_->height,
+            frame_->data,
+            frame_->linesize);
 }
 
-void Encoder::destroy() {
-  if (sws_context_) {
-    sws_freeContext(sws_context_);
-    sws_context_ = nullptr;
-  }
-  if (frame_) {
-    av_frame_free(&frame_);
-    frame_ = nullptr;
-  }
-  if (packet_) {
-    av_packet_free(&packet_);
-    packet_ = nullptr;
-  }
-  if (context_) {
-    avcodec_free_context(&context_);
-    context_ = nullptr;
-  }
-  codec_ = nullptr;
-}
 } // namespace streaming

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -100,7 +100,7 @@ void Encoder::encode() {
   flip_frame();
   rgb_to_yuv();
 
-  encode_frame(frame_);
+  encode_frame(frame_.get());
 
   frame_->pts++;
 }

--- a/streaming/streaming_common/encoder.hpp
+++ b/streaming/streaming_common/encoder.hpp
@@ -29,7 +29,6 @@ private:
   void encode_frame(AVFrame *frame);
   void flip_frame();
   void rgb_to_yuv();
-  void destroy();
 
   std::function<void(const std::byte *data, const std::size_t size, const bool eof)> video_stream_callback_{};
 
@@ -37,10 +36,10 @@ private:
   FrameData rgb_frame_{};
 
   const AVCodec *codec_{};
-  AVCodecContext *context_{};
-  AVPacket *packet_{};
-  AVFrame *frame_{};
+  gp::ffmpeg::UniqueAVCodecContext context_{};
+  gp::ffmpeg::UniqueAVPacket packet_{};
+  gp::ffmpeg::UniqueAVFrame frame_{};
 
-  SwsContext *sws_context_{};
+  gp::ffmpeg::UniqueSwsContext sws_context_{};
 };
 } // namespace streaming


### PR DESCRIPTION
Closes #158

Replaces all raw FFmpeg resource pointers in `Encoder` with the RAII wrappers from `gp::ffmpeg`:
- `AVCodecContext*` → `UniqueAVCodecContext`
- `AVPacket*` → `UniqueAVPacket`
- `AVFrame*` → `UniqueAVFrame`
- `SwsContext*` → `UniqueSwsContext`

Removes all `destroy()` calls in the constructor (RAII handles cleanup on exception) and removes the `destroy()` method entirely.

Also removes the deprecated `AnalyzeTemporaryDtors` key from `.clang-tidy` which was causing clang-tidy build failures.