### PR TITLE
159: Decoder RAII and bug fixes

### DIFF
--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -12,23 +12,19 @@ void Decoder::init(const VideoStreamInfo &video_stream_info) {
 
   rgb_frame_ = std::make_shared<FrameData>(video_stream_info.width * video_stream_info.height * CHANNELS_NUM);
   codec_ = avcodec_find_decoder(video_stream_info.codec_id);
-  context_ = codec_ ? avcodec_alloc_context3(codec_) : nullptr;
-  parser_ = codec_ ? av_parser_init(codec_->id) : nullptr;
-  packet_ = av_packet_alloc();
+  context_.reset(codec_ ? avcodec_alloc_context3(codec_) : nullptr);
+  parser_.reset(codec_ ? av_parser_init(codec_->id) : nullptr);
+  packet_.reset(av_packet_alloc());
   if (codec_ == nullptr) {
-    destroy();
     throw std::runtime_error{"avcodec_find_decoder failed"};
   }
-  if (context_ == nullptr) {
-    destroy();
+  if (!context_) {
     throw std::runtime_error{"avcodec_alloc_context3 failed"};
   }
-  if (parser_ == nullptr) {
-    destroy();
+  if (!parser_) {
     throw std::runtime_error{"av_parser_init failed"};
   }
-  if (packet_ == nullptr) {
-    destroy();
+  if (!packet_) {
     throw std::runtime_error{"av_packet_alloc failed"};
   }
 
@@ -36,14 +32,12 @@ void Decoder::init(const VideoStreamInfo &video_stream_info) {
   context_->height = video_stream_info.height;
   context_->thread_count = DECODE_THREAD_COUNT;
 
-  if (avcodec_open2(context_, codec_, nullptr) < 0) {
-    destroy();
+  if (avcodec_open2(context_.get(), codec_, nullptr) < 0) {
     throw std::runtime_error{"avcodec_open2 failed"};
   }
 
-  frame_ = av_frame_alloc();
-  if (frame_ == nullptr) {
-    destroy();
+  frame_.reset(av_frame_alloc());
+  if (!frame_) {
     throw std::runtime_error{"av_frame_alloc failed"};
   }
 
@@ -54,7 +48,11 @@ void Decoder::init(const VideoStreamInfo &video_stream_info) {
   }
 }
 
-Decoder::~Decoder() { destroy(); }
+Decoder::~Decoder() {
+  if (sws_context_) {
+    sws_freeContext(sws_context_);
+  }
+}
 
 std::shared_ptr<FrameData> Decoder::rgb_frame() {
   if (!rgb_frame_) {
@@ -74,14 +72,17 @@ Decoder::Status Decoder::decode() {
   }
 
   if (packet_sent_) {
-    auto result = avcodec_receive_frame(context_, frame_);
+    auto result = avcodec_receive_frame(context_.get(), frame_.get());
 
     if (result == AVERROR(EAGAIN)) {
       packet_sent_ = false;
       return decode();
     }
     if (result == AVERROR_EOF) {
-      destroy();
+      context_.reset();
+      parser_.reset();
+      packet_.reset();
+      frame_.reset();
       return {Status::Code::EOS};
     }
     if (result < 0) {
@@ -101,7 +102,7 @@ Decoder::Status Decoder::decode() {
 
 bool Decoder::incoming_data(const std::byte *data, const std::size_t size, const bool async) {
   if (!async && !rgb_frame_) {
-    throw std::runtime_error{"Decoder is already initialized"};
+    throw std::runtime_error{"Decoder is not initialized"};
   }
 
   if (signaled_eof_) {
@@ -116,7 +117,9 @@ bool Decoder::incoming_data(const std::byte *data, const std::size_t size, const
   if (buffer_.empty()) {
     buffer_.reserve(size + NULL_PADDING.size());
   } else {
-    buffer_.erase(buffer_.begin() + static_cast<std::int64_t>(buffer_.size()) - NULL_PADDING.size(), buffer_.end());
+    if (buffer_.size() >= NULL_PADDING.size()) {
+      buffer_.erase(buffer_.begin() + static_cast<std::int64_t>(buffer_.size()) - NULL_PADDING.size(), buffer_.end());
+    }
     buffer_.reserve(buffer_.size() + size + NULL_PADDING.size());
   }
 
@@ -131,13 +134,16 @@ bool Decoder::incoming_data(const std::byte *data, const std::size_t size, const
 void Decoder::signal_eof() { signaled_eof_ = true; }
 
 bool Decoder::upload() {
-  consume_async_buffer();
+  for (;;) {
+    consume_async_buffer();
+    const auto eof = buffer_.empty() && signaled_eof_;
+    if (buffer_.empty() && !eof) {
+      break;
+    }
 
-  const auto eof = buffer_.empty() && signaled_eof_;
-  while (!buffer_.empty() || eof) {
     const auto size = buffer_.empty() ? 0u : (buffer_.size() - NULL_PADDING.size());
-    auto result = av_parser_parse2(parser_,
-                                   context_,
+    auto result = av_parser_parse2(parser_.get(),
+                                   context_.get(),
                                    &packet_->data,
                                    &packet_->size,
                                    buffer_.data(),
@@ -149,7 +155,7 @@ bool Decoder::upload() {
     auto used = result;
 
     if (packet_->size != 0) {
-      result = avcodec_send_packet(context_, packet_);
+      result = avcodec_send_packet(context_.get(), packet_.get());
       if (result == 0) {
         reduce_buffer(used);
         packet_sent_ = true;
@@ -182,12 +188,12 @@ bool Decoder::upload() {
       break;
     } else {
       reduce_buffer(used);
-      return upload();
+      // loop back to consume any new async data and retry parsing
     }
   }
 
   if (signaled_eof_) {
-    auto result = avcodec_send_packet(context_, nullptr);
+    auto result = avcodec_send_packet(context_.get(), nullptr);
     if (result == 0 || result == AVERROR_EOF) {
       packet_sent_ = true;
       return true;
@@ -209,30 +215,6 @@ void Decoder::reduce_buffer(int n) {
   } else {
     buffer_.erase(buffer_.begin(), buffer_.begin() + n);
   }
-}
-
-void Decoder::destroy() {
-  if (sws_context_) {
-    sws_freeContext(sws_context_);
-    sws_context_ = nullptr;
-  }
-  if (frame_) {
-    av_frame_free(&frame_);
-    frame_ = nullptr;
-  }
-  if (packet_) {
-    av_packet_free(&packet_);
-    packet_ = nullptr;
-  }
-  if (parser_) {
-    av_parser_close(parser_);
-    parser_ = nullptr;
-  }
-  if (context_) {
-    avcodec_free_context(&context_);
-    context_ = nullptr;
-  }
-  codec_ = nullptr;
 }
 
 void Decoder::yuv_to_rgb() {

--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -118,7 +118,7 @@ bool Decoder::incoming_data(const std::byte *data, const std::size_t size, const
     buffer_.reserve(size + NULL_PADDING.size());
   } else {
     if (buffer_.size() >= NULL_PADDING.size()) {
-      buffer_.erase(buffer_.begin() + static_cast<std::int64_t>(buffer_.size()) - NULL_PADDING.size(), buffer_.end());
+      buffer_.erase(buffer_.end() - NULL_PADDING.size(), buffer_.end());
     }
     buffer_.reserve(buffer_.size() + size + NULL_PADDING.size());
   }
@@ -185,6 +185,9 @@ bool Decoder::upload() {
       }
       throw std::runtime_error("avcodec_send_packet filed with error: " + std::to_string(result));
     } else if (eof) {
+      break;
+    } else if (used == 0) {
+      // Parser consumed nothing and produced no packet — need more input data.
       break;
     } else {
       reduce_buffer(used);

--- a/streaming/streaming_common/decoder.hpp
+++ b/streaming/streaming_common/decoder.hpp
@@ -68,7 +68,6 @@ public:
 private:
   [[nodiscard]] bool upload();
   void reduce_buffer(int n);
-  void destroy();
   void yuv_to_rgb();
   void fill_async_buffer(const std::byte *data, const std::size_t size);
   void consume_async_buffer();
@@ -78,10 +77,10 @@ private:
   std::shared_ptr<FrameData> rgb_frame_{};
 
   const AVCodec *codec_{};
-  AVCodecContext *context_{};
-  AVCodecParserContext *parser_{};
-  AVPacket *packet_{};
-  AVFrame *frame_{};
+  gp::ffmpeg::UniqueAVCodecContext context_{};
+  gp::ffmpeg::UniqueAVCodecParserContext parser_{};
+  gp::ffmpeg::UniqueAVPacket packet_{};
+  gp::ffmpeg::UniqueAVFrame frame_{};
 
   std::vector<std::uint8_t> buffer_{};
 


### PR DESCRIPTION
Closes #159

**RAII refactor**: Replaces all raw FFmpeg resource pointers in `Decoder` with `gp::ffmpeg` RAII wrappers:
- `AVCodecContext*` → `UniqueAVCodecContext`
- `AVCodecParserContext*` → `UniqueAVCodecParserContext`
- `AVPacket*` → `UniqueAVPacket`
- `AVFrame*` → `UniqueAVFrame`

Removes all `destroy()` calls and the `destroy()` method. The destructor now only frees `sws_context_` (a raw `SwsContext*` managed via `sws_getCachedContext`/`sws_freeContext`).

**Bug fixes**:
1. **Wrong error message**: `incoming_data()` threw `"Decoder is already initialized"` when the decoder was *not* initialized — corrected to `"Decoder is not initialized"`
2. **Buffer underflow**: `incoming_data()` erased `NULL_PADDING.size()` bytes from `buffer_` without checking it was large enough — added size guard
3. **Unbounded recursion**: `upload()` called `return upload()` when the parser produced a zero-size packet, leading to a potential stack overflow — converted to a `for(;;)` iterative loop