### PR TITLE
72: Add wall colors and shading to wolf_raycaster

### DIFF
--- a/wolf/wolf_raycaster/raycaster.cpp
+++ b/wolf/wolf_raycaster/raycaster.cpp
@@ -4,6 +4,8 @@
 #include <glm/geometric.hpp>
 #include <gp/utils/utils.hpp>
 
+#include <algorithm>
+#include <cmath>
 #include <numbers>
 
 namespace wolf {
@@ -22,12 +24,14 @@ void Raycaster::cast_rays() {
   const auto scan_start = player_state_.orientation() - (fov_ / 2.0f);
   for (std::size_t r_it = 0; r_it < rays_.size(); r_it++) {
     const auto ray_angle = scan_start + ray_angle_step * static_cast<float>(r_it);
-    auto collision_pos = find_collision(ray_angle);
-    rays_[r_it].dist = project_to_camera_plane(collision_pos);
+    auto collision = find_collision(ray_angle);
+    rays_[r_it].dist = project_to_camera_plane(collision.pos);
+    rays_[r_it].wall = collision.wall;
+    rays_[r_it].x_facing = collision.x_facing;
   }
 }
 
-glm::vec2 Raycaster::find_collision(const float ray_angle) const {
+Raycaster::CollisionResult Raycaster::find_collision(const float ray_angle) const {
   const auto max_depth = std::max(raw_map_.width(), raw_map_.height());
   const auto ray_dir = gp::utils::orientation_to_dir(ray_angle);
   const auto player_block_pos = player_state_.block_pos();
@@ -38,11 +42,13 @@ glm::vec2 Raycaster::find_collision(const float ray_angle) const {
   const auto player_pos = player_state_.pos();
   const auto scan_end = player_pos + ray_dir * line_length_;
   auto result = scan_end;
+  auto result_wall = Map::Walls::nothing;
+  auto result_x_facing = false;
   auto found = false;
   auto min_dist = line_length_;
 
-  const auto intersection_check =
-      [this, &player_pos, &scan_end, &min_dist, &result](const glm::ivec2 &wall_pos) -> bool {
+  const auto intersection_check = [this, &player_pos, &scan_end, &min_dist, &result, &result_wall, &result_x_facing](
+                                      const glm::ivec2 &wall_pos) -> bool {
     if (!raw_map_.is_wall(wall_pos)) {
       return false;
     }
@@ -58,6 +64,14 @@ glm::vec2 Raycaster::find_collision(const float ray_angle) const {
     if (dist < min_dist) {
       min_dist = dist;
       result = line_start;
+      result_wall = raw_map_.block(wall_pos).wall;
+      // Determine face orientation: compare closeness to x-boundary vs y-boundary.
+      // x-facing = hit the left or right face of the block (x is constant).
+      const auto dx = std::min(std::abs(line_start.x - static_cast<float>(wall_pos.x)),
+                               std::abs(line_start.x - static_cast<float>(wall_pos.x + 1)));
+      const auto dy = std::min(std::abs(line_start.y - static_cast<float>(wall_pos.y)),
+                               std::abs(line_start.y - static_cast<float>(wall_pos.y + 1)));
+      result_x_facing = dx < dy;
     }
 
     return true;
@@ -88,7 +102,7 @@ glm::vec2 Raycaster::find_collision(const float ray_angle) const {
     }
   }
 
-  return result;
+  return {result, result_wall, result_x_facing};
 }
 
 float Raycaster::project_to_camera_plane(const glm::vec2 &pos) const {

--- a/wolf/wolf_raycaster/raycaster.hpp
+++ b/wolf/wolf_raycaster/raycaster.hpp
@@ -2,10 +2,13 @@
 
 #include "wolf_common/player_state.hpp"
 #include "wolf_common/raw_map.hpp"
+#include "wolf_common/wolf_map_info.hpp"
 
 namespace wolf {
 struct RayInfo {
   float dist{};
+  Map::Walls wall{Map::Walls::nothing};
+  bool x_facing{};
 };
 
 class Raycaster {
@@ -24,7 +27,13 @@ private:
   float fov_;
   std::vector<RayInfo> rays_{};
 
-  glm::vec2 find_collision(const float ray_angle) const;
+  struct CollisionResult {
+    glm::vec2 pos{};
+    Map::Walls wall{Map::Walls::nothing};
+    bool x_facing{};
+  };
+
+  CollisionResult find_collision(const float ray_angle) const;
   float project_to_camera_plane(const glm::vec2 &pos) const;
 };
 } // namespace wolf

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -88,9 +88,10 @@ void RaycasterScene::draw_walls() const {
     const auto orient_factor = ray.x_facing ? orientation_shadow : 1.0f;
 
     // Proximity shading: walls darken as you approach them.
-    // Discretised into steps to reduce colour banding between adjacent strips.
-    const auto raw_proximity = 1.0f - std::min(max_proximity_shadow, height_multiplier);
-    const auto proximity_factor = static_cast<float>(static_cast<int>(raw_proximity / step_size)) * step_size;
+    // Quantize the shadow amount so that the full [0.25, 1.0] brightness range is reachable.
+    const auto raw_shadow = std::min(max_proximity_shadow, height_multiplier);
+    const auto quantized_shadow = static_cast<float>(static_cast<int>(raw_shadow / step_size)) * step_size;
+    const auto proximity_factor = 1.0f - quantized_shadow;
 
     const auto combined = orient_factor * proximity_factor;
     const auto color = glm::uvec3{static_cast<std::uint32_t>(std::round(static_cast<float>(base_color.r) * combined)),

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -1,5 +1,10 @@
 #include "raycaster_scene.hpp"
 
+#include "wolf_common/map_utils.hpp"
+
+#include <algorithm>
+#include <cmath>
+
 namespace wolf {
 RaycasterScene::RaycasterScene(std::unique_ptr<const RawMap> raw_map, const int fov_in_degrees, const int num_rays)
     : raw_map_{std::move(raw_map)}
@@ -57,17 +62,41 @@ void RaycasterScene::draw_background() const {
 }
 
 void RaycasterScene::draw_walls() const {
+  constexpr auto orientation_shadow = 0.625f;
+  constexpr auto num_steps = 8;
+  constexpr auto max_proximity_shadow = 0.75f;
+  constexpr auto step_size = max_proximity_shadow / num_steps;
+
   const auto &rays = raycaster_.rays();
   const auto strip_width = static_cast<float>(width_) / static_cast<float>(rays.size());
   for (std::size_t ray_index = 0; ray_index < rays.size(); ++ray_index) {
     const auto &ray = rays[ray_index];
+    if (ray.wall == Map::Walls::nothing) {
+      continue;
+    }
+
     const auto height_multiplier = ray.dist > 0.0f ? 1.0f / ray.dist : 1.0f;
     const auto projected_height = height_multiplier * static_cast<float>(height_);
     const auto wall_strip = SDL_FRect{ray_index * strip_width,
                                       (static_cast<float>(height_) - projected_height) / 2.0f,
                                       strip_width,
                                       projected_height};
-    r().set_color(192, 192, 192);
+
+    const auto base_color = MapUtils::wall_color(ray.wall);
+
+    // E/W faces (x-facing) are rendered darker, matching the top-down map shading.
+    const auto orient_factor = ray.x_facing ? orientation_shadow : 1.0f;
+
+    // Proximity shading: walls darken as you approach them.
+    // Discretised into steps to reduce colour banding between adjacent strips.
+    const auto raw_proximity = 1.0f - std::min(max_proximity_shadow, height_multiplier);
+    const auto proximity_factor = static_cast<float>(static_cast<int>(raw_proximity / step_size)) * step_size;
+
+    const auto combined = orient_factor * proximity_factor;
+    const auto color = glm::uvec3{static_cast<std::uint32_t>(std::round(static_cast<float>(base_color.r) * combined)),
+                                  static_cast<std::uint32_t>(std::round(static_cast<float>(base_color.g) * combined)),
+                                  static_cast<std::uint32_t>(std::round(static_cast<float>(base_color.b) * combined))};
+    r().set_color(color);
     r().fill_rect(wall_strip);
   }
 }


### PR DESCRIPTION
Closes #72

Adds per-wall-type colors and two layers of shading to the `wolf_raycaster` 3D projection view.

**Wall colors**
Uses the same palette as the top-down map view (`MapUtils::wall_color()`): grey brick, blue brick, wood, steel, red brick, brown marble, etc.

**Orientation shading**
East/West faces (left/right side of a block, where x is constant) are rendered at 62.5% brightness — matching the `orientation_shadow_factor` already used in the top-down map renderer.

**Proximity shading**
Walls darken as the player approaches them. Formula: `factor = 1 − min(0.75, 1/dist)`, giving ~25% brightness when very close and full brightness beyond ~4 units. Discretised into 8 steps to reduce colour banding between adjacent strips (same technique as `wolf_singlethread`/`wolf_multithread`).

**Implementation**
- `RayInfo` extended with `wall` (`Map::Walls`) and `x_facing` (`bool`)
- `Raycaster::find_collision()` refactored to return a `CollisionResult` struct recording the hit wall type and face orientation (comparing closeness to block x- vs y-boundaries)
- `RaycasterScene::draw_walls()` applies both shading factors combined