### PR TITLE
170: Add wall texture mapping to wolf_raycaster

### DIFF
--- a/gp/sdl/renderer.cpp
+++ b/gp/sdl/renderer.cpp
@@ -170,4 +170,6 @@ void Renderer::draw_text(const std::string &text, const int x, const int y) cons
 
   SDL_RenderTexture(r_->r(), texture.get(), nullptr, &rect);
 }
+
+SDL_Renderer *Renderer::sdl_renderer() const { return r_->r(); }
 } // namespace gp::sdl

--- a/gp/sdl/renderer.hpp
+++ b/gp/sdl/renderer.hpp
@@ -57,6 +57,8 @@ public:
 
   void draw_text(const std::string &text, const int x, const int y) const;
 
+  SDL_Renderer *sdl_renderer() const;
+
   static constexpr auto default_segments = 8u;
 
 private:

--- a/wolf/wolf_raycaster/main.cpp
+++ b/wolf/wolf_raycaster/main.cpp
@@ -1,6 +1,7 @@
 #include "raycaster_scene.hpp"
 
 #include "wolf_common/raw_map_from_wolf.hpp"
+#include "wolf_common/vswap_file.hpp"
 
 #include <cstddef>
 #include <gp/utils/utils.hpp>
@@ -13,6 +14,7 @@
 
 constexpr auto MAPHEAD = "data/MAPHEAD.WL6";
 constexpr auto GAMEMAPS = "data/GAMEMAPS.WL6";
+constexpr auto VSWAP = "data/VSWAP.WL6";
 
 struct ProgramSetup {
   bool exit{};
@@ -81,8 +83,10 @@ int main(int argc, char *argv[]) {
 
   auto raw_map_from_wolf = wolf::RawMapFromWolf{MAPHEAD, GAMEMAPS};
   auto raw_map = raw_map_from_wolf.create_map(program_setup.map_index);
+  auto vswap_file = std::make_shared<const wolf::VswapFile>(VSWAP);
 
-  auto scene = std::make_unique<wolf::RaycasterScene>(std::move(raw_map), program_setup.fov, program_setup.num_rays);
+  auto scene =
+      std::make_unique<wolf::RaycasterScene>(std::move(raw_map), vswap_file, program_setup.fov, program_setup.num_rays);
 
   scene->init(program_setup.width, program_setup.height, "Wolf: Raycaster");
 

--- a/wolf/wolf_raycaster/raycaster.cpp
+++ b/wolf/wolf_raycaster/raycaster.cpp
@@ -28,6 +28,7 @@ void Raycaster::cast_rays() {
     rays_[r_it].dist = project_to_camera_plane(collision.pos);
     rays_[r_it].wall = collision.wall;
     rays_[r_it].x_facing = collision.x_facing;
+    rays_[r_it].tex_u = collision.tex_u;
   }
 }
 
@@ -44,11 +45,13 @@ Raycaster::CollisionResult Raycaster::find_collision(const float ray_angle) cons
   auto result = scan_end;
   auto result_wall = Map::Walls::nothing;
   auto result_x_facing = false;
+  auto result_tex_u = 0.0f;
   auto found = false;
   auto min_dist = line_length_;
 
-  const auto intersection_check = [this, &player_pos, &scan_end, &min_dist, &result, &result_wall, &result_x_facing](
-                                      const glm::ivec2 &wall_pos) -> bool {
+  const auto intersection_check =
+      [this, &player_pos, &scan_end, &min_dist, &result, &result_wall, &result_x_facing, &result_tex_u](
+          const glm::ivec2 &wall_pos) -> bool {
     if (!raw_map_.is_wall(wall_pos)) {
       return false;
     }
@@ -72,6 +75,10 @@ Raycaster::CollisionResult Raycaster::find_collision(const float ray_angle) cons
       const auto dy = std::min(std::abs(line_start.y - static_cast<float>(wall_pos.y)),
                                std::abs(line_start.y - static_cast<float>(wall_pos.y + 1)));
       result_x_facing = dx < dy;
+      // Texture u-coordinate: fractional part of the component that varies along the face.
+      const auto raw_u =
+          result_x_facing ? (line_start.y - std::floor(line_start.y)) : (line_start.x - std::floor(line_start.x));
+      result_tex_u = raw_u < 0.0f ? raw_u + 1.0f : raw_u;
     }
 
     return true;
@@ -102,7 +109,7 @@ Raycaster::CollisionResult Raycaster::find_collision(const float ray_angle) cons
     }
   }
 
-  return {result, result_wall, result_x_facing};
+  return {result, result_wall, result_x_facing, result_tex_u};
 }
 
 float Raycaster::project_to_camera_plane(const glm::vec2 &pos) const {

--- a/wolf/wolf_raycaster/raycaster.cpp
+++ b/wolf/wolf_raycaster/raycaster.cpp
@@ -50,7 +50,7 @@ Raycaster::CollisionResult Raycaster::find_collision(const float ray_angle) cons
   auto min_dist = line_length_;
 
   const auto intersection_check =
-      [this, &player_pos, &scan_end, &min_dist, &result, &result_wall, &result_x_facing, &result_tex_u](
+      [this, &player_pos, &scan_end, &ray_dir, &min_dist, &result, &result_wall, &result_x_facing, &result_tex_u](
           const glm::ivec2 &wall_pos) -> bool {
     if (!raw_map_.is_wall(wall_pos)) {
       return false;
@@ -75,10 +75,13 @@ Raycaster::CollisionResult Raycaster::find_collision(const float ray_angle) cons
       const auto dy = std::min(std::abs(line_start.y - static_cast<float>(wall_pos.y)),
                                std::abs(line_start.y - static_cast<float>(wall_pos.y + 1)));
       result_x_facing = dx < dy;
-      // Texture u-coordinate: fractional part of the component that varies along the face.
+      // Texture u-coordinate: fractional part of the component that varies along the face,
+      // flipped based on ray direction so the texture reads consistently left-to-right from
+      // the viewer's perspective regardless of which face is hit.
       const auto raw_u =
           result_x_facing ? (line_start.y - std::floor(line_start.y)) : (line_start.x - std::floor(line_start.x));
-      result_tex_u = raw_u < 0.0f ? raw_u + 1.0f : raw_u;
+      const auto flip = (result_x_facing && ray_dir.x < 0.0f) || (!result_x_facing && ray_dir.y < 0.0f);
+      result_tex_u = flip ? (1.0f - raw_u) : raw_u;
     }
 
     return true;

--- a/wolf/wolf_raycaster/raycaster.hpp
+++ b/wolf/wolf_raycaster/raycaster.hpp
@@ -9,6 +9,7 @@ struct RayInfo {
   float dist{};
   Map::Walls wall{Map::Walls::nothing};
   bool x_facing{};
+  float tex_u{};
 };
 
 class Raycaster {
@@ -31,6 +32,7 @@ private:
     glm::vec2 pos{};
     Map::Walls wall{Map::Walls::nothing};
     bool x_facing{};
+    float tex_u{};
   };
 
   CollisionResult find_collision(const float ray_angle) const;

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -106,9 +106,9 @@ void RaycasterScene::draw_walls() const {
     const auto wall_top = (static_cast<float>(height_) - projected_height) / 2.0f;
     const auto wall_strip = SDL_FRect{ray_index * strip_width, wall_top, strip_width, projected_height};
 
-    // Select texture: direct index from wall type (one texture per wall id).
+    // VSWAP stores textures in pairs per wall type: even index = N/S (dark), odd = E/W (light).
     const auto wall_val = static_cast<std::size_t>(ray.wall);
-    const auto tex_idx = wall_val - 1;
+    const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1u : 0u);
 
     if (tex_idx >= wall_textures_.size()) {
       continue;
@@ -119,12 +119,9 @@ void RaycasterScene::draw_walls() const {
     const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
 
     // Proximity shading via texture colour mod (discretised to reduce banding).
-    // E/W (x-facing) walls use the same orientation shadow factor as the vector map.
-    constexpr auto orientation_shadow_factor = 0.625f;
-    const auto orientation_factor = ray.x_facing ? orientation_shadow_factor : 1.0f;
     const auto raw_proximity = 1.0f - std::min(max_proximity_shadow, height_multiplier);
     const auto proximity_factor = static_cast<float>(static_cast<int>(raw_proximity / step_size)) * step_size;
-    const auto shade = static_cast<std::uint8_t>(std::round(proximity_factor * orientation_factor * 255.0f));
+    const auto shade = static_cast<std::uint8_t>(std::round(proximity_factor * 255.0f));
 
     auto *tex = wall_textures_[tex_idx].get();
     SDL_SetTextureColorMod(tex, shade, shade, shade);

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -48,6 +48,9 @@ void RaycasterScene::resize(const int width, const int height) {
 }
 
 void RaycasterScene::init_wall_textures() {
+  if (!vswap_file_) {
+    throw std::runtime_error("VswapFile is null: cannot initialize wall textures");
+  }
   const auto &walls = vswap_file_->walls();
   wall_textures_.reserve(walls.size());
   for (const auto &tex_data : walls) {

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -1,7 +1,5 @@
 #include "raycaster_scene.hpp"
 
-#include "wolf_common/map_utils.hpp"
-
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
@@ -106,26 +104,28 @@ void RaycasterScene::draw_walls() const {
     const auto wall_top = (static_cast<float>(height_) - projected_height) / 2.0f;
     const auto wall_strip = SDL_FRect{ray_index * strip_width, wall_top, strip_width, projected_height};
 
-    // VSWAP stores textures in pairs per wall type: even index = N/S (dark), odd = E/W (light).
-    const auto wall_val = static_cast<std::size_t>(ray.wall);
-    const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1u : 0u);
-
-    if (tex_idx >= wall_textures_.size()) {
-      continue;
-    }
-
-    // Source column from the 64×64 texture based on the hit u-coordinate.
-    const auto tex_col = std::clamp(static_cast<int>(ray.tex_u * 64.0f), 0, 63);
-    const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
-
-    // Proximity shading via texture colour mod (discretised to reduce banding).
+    // Proximity shading factor (discretised to reduce banding).
     const auto raw_proximity = 1.0f - std::min(max_proximity_shadow, height_multiplier);
     const auto proximity_factor = static_cast<float>(static_cast<int>(raw_proximity / step_size)) * step_size;
     const auto shade = static_cast<std::uint8_t>(std::round(proximity_factor * 255.0f));
 
-    auto *tex = wall_textures_[tex_idx].get();
-    SDL_SetTextureColorMod(tex, shade, shade, shade);
-    SDL_RenderTexture(sdl_r_, tex, &src, &wall_strip);
+    // VSWAP stores textures in pairs per wall type: even index = N/S (dark), odd = E/W (light).
+    const auto wall_val = static_cast<std::size_t>(ray.wall);
+    const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1u : 0u);
+
+    if (tex_idx < wall_textures_.size()) {
+      // Source column from the 64×64 texture based on the hit u-coordinate.
+      const auto tex_col = std::clamp(static_cast<int>(ray.tex_u * 64.0f), 0, 63);
+      const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
+
+      auto *tex = wall_textures_[tex_idx].get();
+      SDL_SetTextureColorMod(tex, shade, shade, shade);
+      SDL_RenderTexture(sdl_r_, tex, &src, &wall_strip);
+    } else {
+      // Fallback for wall types without a VSWAP texture pair (e.g. doors, elevator).
+      r().set_color(shade, shade, shade);
+      r().fill_rect(wall_strip);
+    }
   }
 }
 } // namespace wolf

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -6,8 +6,12 @@
 #include <cmath>
 
 namespace wolf {
-RaycasterScene::RaycasterScene(std::unique_ptr<const RawMap> raw_map, const int fov_in_degrees, const int num_rays)
+RaycasterScene::RaycasterScene(std::unique_ptr<const RawMap> raw_map,
+                               std::shared_ptr<const VswapFile> vswap_file,
+                               const int fov_in_degrees,
+                               const int num_rays)
     : raw_map_{std::move(raw_map)}
+    , vswap_file_{std::move(vswap_file)}
     , raycaster_{*raw_map_, player_state_, fov_in_degrees, num_rays} {}
 
 void RaycasterScene::loop(const gp::misc::Event &event) {
@@ -15,6 +19,8 @@ void RaycasterScene::loop(const gp::misc::Event &event) {
   case gp::misc::Event::Type::Init:
     last_timestamp_ms_ = event.timestamp();
     player_state_.set_keyboard_state(keyboard_state());
+    sdl_r_ = renderer()->sdl_renderer();
+    init_wall_textures();
     resize(event.init().width, event.init().height);
     break;
   case gp::misc::Event::Type::Quit:
@@ -40,6 +46,17 @@ void RaycasterScene::resize(const int width, const int height) {
   height_ = height;
 }
 
+void RaycasterScene::init_wall_textures() {
+  const auto &walls = vswap_file_->walls();
+  wall_textures_.reserve(walls.size());
+  for (const auto &tex_data : walls) {
+    auto *tex = SDL_CreateTexture(sdl_r_, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, 64, 64);
+    SDL_UpdateTexture(tex, nullptr, tex_data.data(), 64 * 4);
+    SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_NONE);
+    wall_textures_.emplace_back(tex, SDL_DestroyTexture);
+  }
+}
+
 void RaycasterScene::redraw() {
   r().set_color(0, 0, 0);
   r().clear();
@@ -62,7 +79,6 @@ void RaycasterScene::draw_background() const {
 }
 
 void RaycasterScene::draw_walls() const {
-  constexpr auto orientation_shadow = 0.625f;
   constexpr auto num_steps = 8;
   constexpr auto max_proximity_shadow = 0.75f;
   constexpr auto step_size = max_proximity_shadow / num_steps;
@@ -77,28 +93,29 @@ void RaycasterScene::draw_walls() const {
 
     const auto height_multiplier = ray.dist > 0.0f ? 1.0f / ray.dist : 1.0f;
     const auto projected_height = height_multiplier * static_cast<float>(height_);
-    const auto wall_strip = SDL_FRect{ray_index * strip_width,
-                                      (static_cast<float>(height_) - projected_height) / 2.0f,
-                                      strip_width,
-                                      projected_height};
+    const auto wall_top = (static_cast<float>(height_) - projected_height) / 2.0f;
+    const auto wall_strip = SDL_FRect{ray_index * strip_width, wall_top, strip_width, projected_height};
 
-    const auto base_color = MapUtils::wall_color(ray.wall);
+    // Select texture: two variants per wall type; even = N/S (light), odd = E/W (dark).
+    const auto wall_val = static_cast<std::size_t>(ray.wall);
+    const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1 : 0);
 
-    // E/W faces (x-facing) are rendered darker, matching the top-down map shading.
-    const auto orient_factor = ray.x_facing ? orientation_shadow : 1.0f;
+    if (tex_idx >= wall_textures_.size()) {
+      continue;
+    }
 
-    // Proximity shading: walls darken as you approach them.
-    // Quantize the shadow amount so that the full [0.25, 1.0] brightness range is reachable.
-    const auto raw_shadow = std::min(max_proximity_shadow, height_multiplier);
-    const auto quantized_shadow = static_cast<float>(static_cast<int>(raw_shadow / step_size)) * step_size;
-    const auto proximity_factor = 1.0f - quantized_shadow;
+    // Source column from the 64×64 texture based on the hit u-coordinate.
+    const auto tex_col = static_cast<int>(ray.tex_u * 64.0f);
+    const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
 
-    const auto combined = orient_factor * proximity_factor;
-    const auto color = glm::uvec3{static_cast<std::uint32_t>(std::round(static_cast<float>(base_color.r) * combined)),
-                                  static_cast<std::uint32_t>(std::round(static_cast<float>(base_color.g) * combined)),
-                                  static_cast<std::uint32_t>(std::round(static_cast<float>(base_color.b) * combined))};
-    r().set_color(color);
-    r().fill_rect(wall_strip);
+    // Proximity shading via texture colour mod (discretised to reduce banding).
+    const auto raw_proximity = 1.0f - std::min(max_proximity_shadow, height_multiplier);
+    const auto proximity_factor = static_cast<float>(static_cast<int>(raw_proximity / step_size)) * step_size;
+    const auto shade = static_cast<std::uint8_t>(std::round(proximity_factor * 255.0f));
+
+    auto *tex = wall_textures_[tex_idx].get();
+    SDL_SetTextureColorMod(tex, shade, shade, shade);
+    SDL_RenderTexture(sdl_r_, tex, &src, &wall_strip);
   }
 }
 } // namespace wolf

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -103,9 +103,9 @@ void RaycasterScene::draw_walls() const {
     const auto wall_top = (static_cast<float>(height_) - projected_height) / 2.0f;
     const auto wall_strip = SDL_FRect{ray_index * strip_width, wall_top, strip_width, projected_height};
 
-    // Select texture: two variants per wall type; even = N/S (light), odd = E/W (dark).
+    // Select texture: direct index from wall type (one texture per wall id).
     const auto wall_val = static_cast<std::size_t>(ray.wall);
-    const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1 : 0);
+    const auto tex_idx = wall_val - 1;
 
     if (tex_idx >= wall_textures_.size()) {
       continue;
@@ -116,9 +116,12 @@ void RaycasterScene::draw_walls() const {
     const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
 
     // Proximity shading via texture colour mod (discretised to reduce banding).
+    // E/W (x-facing) walls use the same orientation shadow factor as the vector map.
+    constexpr auto orientation_shadow_factor = 0.625f;
+    const auto orientation_factor = ray.x_facing ? orientation_shadow_factor : 1.0f;
     const auto raw_proximity = 1.0f - std::min(max_proximity_shadow, height_multiplier);
     const auto proximity_factor = static_cast<float>(static_cast<int>(raw_proximity / step_size)) * step_size;
-    const auto shade = static_cast<std::uint8_t>(std::round(proximity_factor * 255.0f));
+    const auto shade = static_cast<std::uint8_t>(std::round(proximity_factor * orientation_factor * 255.0f));
 
     auto *tex = wall_textures_[tex_idx].get();
     SDL_SetTextureColorMod(tex, shade, shade, shade);

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 namespace wolf {
 RaycasterScene::RaycasterScene(std::unique_ptr<const RawMap> raw_map,
@@ -51,7 +52,13 @@ void RaycasterScene::init_wall_textures() {
   wall_textures_.reserve(walls.size());
   for (const auto &tex_data : walls) {
     auto *tex = SDL_CreateTexture(sdl_r_, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, 64, 64);
-    SDL_UpdateTexture(tex, nullptr, tex_data.data(), 64 * 4);
+    if (!tex) {
+      throw std::runtime_error(std::string("SDL_CreateTexture failed: ") + SDL_GetError());
+    }
+    if (!SDL_UpdateTexture(tex, nullptr, tex_data.data(), 64 * 4)) {
+      SDL_DestroyTexture(tex);
+      throw std::runtime_error(std::string("SDL_UpdateTexture failed: ") + SDL_GetError());
+    }
     SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_NONE);
     wall_textures_.emplace_back(tex, SDL_DestroyTexture);
   }
@@ -105,7 +112,7 @@ void RaycasterScene::draw_walls() const {
     }
 
     // Source column from the 64×64 texture based on the hit u-coordinate.
-    const auto tex_col = static_cast<int>(ray.tex_u * 64.0f);
+    const auto tex_col = std::clamp(static_cast<int>(ray.tex_u * 64.0f), 0, 63);
     const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
 
     // Proximity shading via texture colour mod (discretised to reduce banding).

--- a/wolf/wolf_raycaster/raycaster_scene.hpp
+++ b/wolf/wolf_raycaster/raycaster_scene.hpp
@@ -4,15 +4,21 @@
 
 #include "wolf_common/player_state.hpp"
 #include "wolf_common/raw_map.hpp"
+#include "wolf_common/vswap_file.hpp"
 
 #include <gp/sdl/scene_2d.hpp>
+#include <gp/sdl/sdl.hpp>
 
 #include <memory>
+#include <vector>
 
 namespace wolf {
 class RaycasterScene : public gp::sdl::Scene2D {
 public:
-  RaycasterScene(std::unique_ptr<const RawMap> raw_map, const int fov_in_degrees, const int num_rays);
+  RaycasterScene(std::unique_ptr<const RawMap> raw_map,
+                 std::shared_ptr<const VswapFile> vswap_file,
+                 const int fov_in_degrees,
+                 const int num_rays);
 
 private:
   void loop(const gp::misc::Event &event) override;
@@ -20,14 +26,19 @@ private:
   void resize(const int width, const int height);
   void redraw();
 
+  void init_wall_textures();
   void draw_background() const;
   void draw_walls() const;
 
   const std::unique_ptr<const RawMap> raw_map_{};
+  std::shared_ptr<const VswapFile> vswap_file_{};
   PlayerState player_state_{*raw_map_};
   Raycaster raycaster_;
   int width_{};
   int height_{};
   std::uint32_t last_timestamp_ms_{0u};
+
+  SDL_Renderer *sdl_r_{};
+  std::vector<std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)>> wall_textures_;
 };
 } // namespace wolf


### PR DESCRIPTION
Closes #170

Implements texture mapping on raycaster walls using actual VSWAP.WL6 game textures:

* Adds `sdl_renderer()` accessor to `gp::sdl::Renderer`
* Adds `tex_u` texture coordinate to `RayInfo` / `CollisionResult`; computed from fractional hit position
* Loads `VswapFile` in `RaycasterScene`; creates SDL textures at init with null guard and error handling
* VSWAP stores textures in pairs per wall type: even index = N/S (dark variant), odd = E/W (light variant); selects via `(wall_val-1)*2 + x_facing`
* Proximity shading via `SDL_SetTextureColorMod` (close walls darker)