### PR TITLE
172: Add runtime toggles to wolf_raycaster

### DIFF
--- a/wolf/wolf_common/map_renderer.cpp
+++ b/wolf/wolf_common/map_renderer.cpp
@@ -16,6 +16,8 @@ MapRenderer::MapRenderer(const VectorMap &vector_map,
 
 void MapRenderer::set_renderer(std::shared_ptr<const gp::sdl::Renderer> renderer) { r_ = std::move(renderer); }
 
+void MapRenderer::set_player_oriented(const bool player_oriented) { player_oriented_ = player_oriented; }
+
 void MapRenderer::resize(const int width, const int height) {
   scale_ = std::min(width, height) / vector_map_.diagonal_length();
   screen_center_translation_ = glm::vec3{static_cast<float>(width) / 2.0f, static_cast<float>(height) / 2.0f, 0.0f};

--- a/wolf/wolf_common/map_renderer.hpp
+++ b/wolf/wolf_common/map_renderer.hpp
@@ -19,6 +19,7 @@ public:
               const bool player_oriented = false);
 
   void set_renderer(std::shared_ptr<const gp::sdl::Renderer> renderer);
+  void set_player_oriented(const bool player_oriented);
   void resize(const int width, const int height);
   void redraw();
 
@@ -32,7 +33,7 @@ private:
   const VectorMap &vector_map_;
   const PlayerState &player_state_;
   const float fov_in_rad_{};
-  const bool player_oriented_{};
+  bool player_oriented_{};
 
   std::shared_ptr<const gp::sdl::Renderer> r_{};
 

--- a/wolf/wolf_common/map_utils.hpp
+++ b/wolf/wolf_common/map_utils.hpp
@@ -5,5 +5,10 @@
 #include <glm/vec3.hpp>
 
 namespace wolf::MapUtils {
+
+// Brightness factor applied to E/W-facing walls to give the illusion of directional lighting.
+// Used by both the map overlay (VectorMap) and the solid-color raycaster path.
+inline constexpr auto orientation_shadow_factor = 0.625f;
+
 glm::uvec3 wall_color(const Map::Walls wall);
 } // namespace wolf::MapUtils

--- a/wolf/wolf_common/vector_map.cpp
+++ b/wolf/wolf_common/vector_map.cpp
@@ -29,8 +29,6 @@ float VectorMap::height() const { return height_; }
 float VectorMap::diagonal_length() const { return diagonal_length_; }
 
 void VectorMap::generate_vector_map(const RawMap &raw_map) {
-  constexpr auto orientation_shadow_factor{0.625f};
-
   for (int h = 0; h < raw_map.height(); h++) {
     for (int w = 0; w < raw_map.width(); w++) {
       if (raw_map.is_wall(w, h)) {
@@ -46,15 +44,15 @@ void VectorMap::generate_vector_map(const RawMap &raw_map) {
         }
         if (raw_map.is_within_bounds(w - 1, h) && !raw_map.is_wall(w - 1, h)) {
           vectors_.emplace_back(glm::vec2{w, h + 1}, glm::vec2{w, h});
-          colors_.push_back(glm::uvec3{std::round(_wall_color.r * orientation_shadow_factor),
-                                       std::round(_wall_color.g * orientation_shadow_factor),
-                                       std::round(_wall_color.b * orientation_shadow_factor)});
+          colors_.push_back(glm::uvec3{std::round(_wall_color.r * MapUtils::orientation_shadow_factor),
+                                       std::round(_wall_color.g * MapUtils::orientation_shadow_factor),
+                                       std::round(_wall_color.b * MapUtils::orientation_shadow_factor)});
         }
         if (raw_map.is_within_bounds(w + 1, h) && !raw_map.is_wall(w + 1, h)) {
           vectors_.emplace_back(glm::vec2{w + 1, h}, glm::vec2{w + 1, h + 1});
-          colors_.push_back(glm::uvec3{std::round(_wall_color.r * orientation_shadow_factor),
-                                       std::round(_wall_color.g * orientation_shadow_factor),
-                                       std::round(_wall_color.b * orientation_shadow_factor)});
+          colors_.push_back(glm::uvec3{std::round(_wall_color.r * MapUtils::orientation_shadow_factor),
+                                       std::round(_wall_color.g * MapUtils::orientation_shadow_factor),
+                                       std::round(_wall_color.b * MapUtils::orientation_shadow_factor)});
         }
       }
     }

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -1,8 +1,12 @@
 #include "raycaster_scene.hpp"
 
+#include "wolf_common/map_utils.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
+
+#include <glm/vec3.hpp>
 
 namespace wolf {
 RaycasterScene::RaycasterScene(std::unique_ptr<const RawMap> raw_map,
@@ -101,6 +105,8 @@ void RaycasterScene::redraw() {
     map_renderer_.redraw();
   }
 
+  draw_help_overlay();
+
   r().present();
 }
 
@@ -162,18 +168,60 @@ void RaycasterScene::draw_walls() const {
         r().fill_rect(wall_strip);
       }
     } else {
-      // Solid color from VectorMap, with optional orientation + proximity shading.
-      const auto wall_val = static_cast<std::size_t>(ray.wall);
-      auto shadow = show_shading_ ? (ray.x_facing ? orientation_shadow_factor : 1.0f) : 1.0f;
+      // Solid color matching the map overlay: use wall_color() + orientation shadow for E/W faces.
+      const auto base_color = MapUtils::wall_color(ray.wall);
+      auto shadow = 1.0f;
       if (show_shading_) {
+        shadow = ray.x_facing ? orientation_shadow_factor : 1.0f;
         const auto raw = 1.0f - std::min(max_proximity_shadow, height_multiplier);
         const auto stepped = static_cast<float>(static_cast<int>(raw / step_size)) * step_size;
         shadow *= stepped;
+      } else {
+        shadow = ray.x_facing ? orientation_shadow_factor : 1.0f;
       }
-      const auto color = vector_map_.color(wall_val - 1, shadow);
-      r().set_color(color);
+      r().set_color(glm::uvec3{static_cast<unsigned>(std::round(base_color.r * shadow)),
+                               static_cast<unsigned>(std::round(base_color.g * shadow)),
+                               static_cast<unsigned>(std::round(base_color.b * shadow))});
       r().fill_rect(wall_strip);
     }
   }
+}
+
+void RaycasterScene::draw_help_overlay() const {
+  constexpr auto scale = 2.0f;
+  constexpr auto ch = 8; // SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE
+  constexpr auto line_h = ch + 4;
+  constexpr auto padding = 6;
+  constexpr auto num_lines = 4;
+  constexpr auto max_chars = 18;
+
+  float prev_sx{}, prev_sy{};
+  SDL_GetRenderScale(sdl_r_, &prev_sx, &prev_sy);
+  SDL_SetRenderScale(sdl_r_, scale, scale);
+
+  const auto log_h = static_cast<float>(height_) / scale;
+  const auto bg_w = static_cast<float>(max_chars * ch + padding * 2);
+  const auto bg_h = static_cast<float>(num_lines * line_h - 4 + padding * 2);
+  const auto bg_x = static_cast<float>(padding);
+  const auto bg_y = log_h - bg_h - static_cast<float>(padding);
+
+  SDL_SetRenderDrawBlendMode(sdl_r_, SDL_BLENDMODE_BLEND);
+  SDL_SetRenderDrawColor(sdl_r_, 0, 0, 0, 180);
+  const SDL_FRect bg{bg_x, bg_y, bg_w, bg_h};
+  SDL_RenderFillRect(sdl_r_, &bg);
+  SDL_SetRenderDrawBlendMode(sdl_r_, SDL_BLENDMODE_NONE);
+
+  SDL_SetRenderDrawColor(sdl_r_, 220, 220, 220, 255);
+  const auto tx = bg_x + padding;
+  auto ty = bg_y + padding;
+  SDL_RenderDebugText(sdl_r_, tx, ty, show_textures_ ? "T: Textures [on ]" : "T: Textures [off]");
+  ty += line_h;
+  SDL_RenderDebugText(sdl_r_, tx, ty, show_shading_ ? "G: Shading  [on ]" : "G: Shading  [off]");
+  ty += line_h;
+  SDL_RenderDebugText(sdl_r_, tx, ty, show_map_ ? "M: Map      [on ]" : "M: Map      [off]");
+  ty += line_h;
+  SDL_RenderDebugText(sdl_r_, tx, ty, map_player_oriented_ ? "O: Map [player-up]" : "O: Map [north-up ]");
+
+  SDL_SetRenderScale(sdl_r_, prev_sx, prev_sy);
 }
 } // namespace wolf

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -11,7 +11,8 @@ RaycasterScene::RaycasterScene(std::unique_ptr<const RawMap> raw_map,
                                const int num_rays)
     : raw_map_{std::move(raw_map)}
     , vswap_file_{std::move(vswap_file)}
-    , raycaster_{*raw_map_, player_state_, fov_in_degrees, num_rays} {}
+    , raycaster_{*raw_map_, player_state_, fov_in_degrees, num_rays}
+    , map_renderer_{vector_map_, player_state_, static_cast<std::uint32_t>(fov_in_degrees)} {}
 
 void RaycasterScene::loop(const gp::misc::Event &event) {
   switch (event.type()) {
@@ -19,10 +20,12 @@ void RaycasterScene::loop(const gp::misc::Event &event) {
     last_timestamp_ms_ = event.timestamp();
     player_state_.set_keyboard_state(keyboard_state());
     sdl_r_ = renderer()->sdl_renderer();
+    map_renderer_.set_renderer(renderer());
     init_wall_textures();
     resize(event.init().width, event.init().height);
     break;
   case gp::misc::Event::Type::Quit:
+    map_renderer_.set_renderer(nullptr);
     player_state_.set_keyboard_state(nullptr);
     break;
   case gp::misc::Event::Type::Resize:
@@ -35,6 +38,27 @@ void RaycasterScene::loop(const gp::misc::Event &event) {
     last_timestamp_ms_ = event.timestamp();
     redraw();
   } break;
+  case gp::misc::Event::Type::Key:
+    if (event.key().action == gp::misc::Event::Action::Pressed) {
+      switch (event.key().scan_code) {
+      case gp::misc::Event::ScanCode::T:
+        show_textures_ = !show_textures_;
+        break;
+      case gp::misc::Event::ScanCode::G:
+        show_shading_ = !show_shading_;
+        break;
+      case gp::misc::Event::ScanCode::M:
+        show_map_ = !show_map_;
+        break;
+      case gp::misc::Event::ScanCode::O:
+        map_renderer_.set_player_oriented(!map_player_oriented_);
+        map_player_oriented_ = !map_player_oriented_;
+        break;
+      default:
+        break;
+      }
+    }
+    break;
   default:
     break;
   }
@@ -43,6 +67,7 @@ void RaycasterScene::loop(const gp::misc::Event &event) {
 void RaycasterScene::resize(const int width, const int height) {
   width_ = width;
   height_ = height;
+  map_renderer_.resize(width, height);
 }
 
 void RaycasterScene::init_wall_textures() {
@@ -72,6 +97,10 @@ void RaycasterScene::redraw() {
   draw_background();
   draw_walls();
 
+  if (show_map_) {
+    map_renderer_.redraw();
+  }
+
   r().present();
 }
 
@@ -90,6 +119,7 @@ void RaycasterScene::draw_walls() const {
   constexpr auto num_steps = 8;
   constexpr auto max_proximity_shadow = 0.75f;
   constexpr auto step_size = max_proximity_shadow / num_steps;
+  constexpr auto orientation_shadow_factor = 0.625f;
 
   const auto &rays = raycaster_.rays();
   const auto strip_width = static_cast<float>(width_) / static_cast<float>(rays.size());
@@ -104,26 +134,44 @@ void RaycasterScene::draw_walls() const {
     const auto wall_top = (static_cast<float>(height_) - projected_height) / 2.0f;
     const auto wall_strip = SDL_FRect{ray_index * strip_width, wall_top, strip_width, projected_height};
 
-    // Proximity shading factor (discretised to reduce banding).
-    const auto raw_proximity = 1.0f - std::min(max_proximity_shadow, height_multiplier);
-    const auto proximity_factor = static_cast<float>(static_cast<int>(raw_proximity / step_size)) * step_size;
-    const auto shade = static_cast<std::uint8_t>(std::round(proximity_factor * 255.0f));
+    if (show_textures_) {
+      // VSWAP stores textures in pairs per wall type: even index = N/S (dark), odd = E/W (light).
+      const auto wall_val = static_cast<std::size_t>(ray.wall);
+      const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1u : 0u);
 
-    // VSWAP stores textures in pairs per wall type: even index = N/S (dark), odd = E/W (light).
-    const auto wall_val = static_cast<std::size_t>(ray.wall);
-    const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1u : 0u);
+      const auto proximity_shade = [&]() -> std::uint8_t {
+        if (!show_shading_) {
+          return 255u;
+        }
+        const auto raw = 1.0f - std::min(max_proximity_shadow, height_multiplier);
+        const auto stepped = static_cast<float>(static_cast<int>(raw / step_size)) * step_size;
+        return static_cast<std::uint8_t>(std::round(stepped * 255.0f));
+      }();
 
-    if (tex_idx < wall_textures_.size()) {
-      // Source column from the 64×64 texture based on the hit u-coordinate.
-      const auto tex_col = std::clamp(static_cast<int>(ray.tex_u * 64.0f), 0, 63);
-      const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
+      if (tex_idx < wall_textures_.size()) {
+        // Source column from the 64×64 texture based on the hit u-coordinate.
+        const auto tex_col = std::clamp(static_cast<int>(ray.tex_u * 64.0f), 0, 63);
+        const auto src = SDL_FRect{static_cast<float>(tex_col), 0.0f, 1.0f, 64.0f};
 
-      auto *tex = wall_textures_[tex_idx].get();
-      SDL_SetTextureColorMod(tex, shade, shade, shade);
-      SDL_RenderTexture(sdl_r_, tex, &src, &wall_strip);
+        auto *tex = wall_textures_[tex_idx].get();
+        SDL_SetTextureColorMod(tex, proximity_shade, proximity_shade, proximity_shade);
+        SDL_RenderTexture(sdl_r_, tex, &src, &wall_strip);
+      } else {
+        // Fallback for wall types without a VSWAP texture pair (e.g. doors, elevator).
+        r().set_color(proximity_shade, proximity_shade, proximity_shade);
+        r().fill_rect(wall_strip);
+      }
     } else {
-      // Fallback for wall types without a VSWAP texture pair (e.g. doors, elevator).
-      r().set_color(shade, shade, shade);
+      // Solid color from VectorMap, with optional orientation + proximity shading.
+      const auto wall_val = static_cast<std::size_t>(ray.wall);
+      auto shadow = show_shading_ ? (ray.x_facing ? orientation_shadow_factor : 1.0f) : 1.0f;
+      if (show_shading_) {
+        const auto raw = 1.0f - std::min(max_proximity_shadow, height_multiplier);
+        const auto stepped = static_cast<float>(static_cast<int>(raw / step_size)) * step_size;
+        shadow *= stepped;
+      }
+      const auto color = vector_map_.color(wall_val - 1, shadow);
+      r().set_color(color);
       r().fill_rect(wall_strip);
     }
   }

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -125,7 +125,6 @@ void RaycasterScene::draw_walls() const {
   constexpr auto num_steps = 8;
   constexpr auto max_proximity_shadow = 0.75f;
   constexpr auto step_size = max_proximity_shadow / num_steps;
-  constexpr auto orientation_shadow_factor = 0.625f;
 
   const auto &rays = raycaster_.rays();
   const auto strip_width = static_cast<float>(width_) / static_cast<float>(rays.size());
@@ -141,7 +140,7 @@ void RaycasterScene::draw_walls() const {
     const auto wall_strip = SDL_FRect{ray_index * strip_width, wall_top, strip_width, projected_height};
 
     if (show_textures_) {
-      // VSWAP stores textures in pairs per wall type: even index = N/S (dark), odd = E/W (light).
+      // VSWAP stores textures in pairs per wall type: even index = N/S (light), odd = E/W (dark).
       const auto wall_val = static_cast<std::size_t>(ray.wall);
       const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1u : 0u);
 
@@ -172,12 +171,10 @@ void RaycasterScene::draw_walls() const {
       const auto base_color = MapUtils::wall_color(ray.wall);
       auto shadow = 1.0f;
       if (show_shading_) {
-        shadow = ray.x_facing ? orientation_shadow_factor : 1.0f;
+        shadow = ray.x_facing ? MapUtils::orientation_shadow_factor : 1.0f;
         const auto raw = 1.0f - std::min(max_proximity_shadow, height_multiplier);
         const auto stepped = static_cast<float>(static_cast<int>(raw / step_size)) * step_size;
         shadow *= stepped;
-      } else {
-        shadow = ray.x_facing ? orientation_shadow_factor : 1.0f;
       }
       r().set_color(glm::uvec3{static_cast<unsigned>(std::round(base_color.r * shadow)),
                                static_cast<unsigned>(std::round(base_color.g * shadow)),

--- a/wolf/wolf_raycaster/raycaster_scene.cpp
+++ b/wolf/wolf_raycaster/raycaster_scene.cpp
@@ -49,7 +49,10 @@ void RaycasterScene::loop(const gp::misc::Event &event) {
         show_textures_ = !show_textures_;
         break;
       case gp::misc::Event::ScanCode::G:
-        show_shading_ = !show_shading_;
+        show_proximity_shading_ = !show_proximity_shading_;
+        break;
+      case gp::misc::Event::ScanCode::L:
+        show_orientation_shading_ = !show_orientation_shading_;
         break;
       case gp::misc::Event::ScanCode::M:
         show_map_ = !show_map_;
@@ -140,12 +143,13 @@ void RaycasterScene::draw_walls() const {
     const auto wall_strip = SDL_FRect{ray_index * strip_width, wall_top, strip_width, projected_height};
 
     if (show_textures_) {
-      // VSWAP stores textures in pairs per wall type: even index = N/S (light), odd = E/W (dark).
+      // Orientation: pick E/W (dark) variant when enabled, otherwise always use N/S (light).
       const auto wall_val = static_cast<std::size_t>(ray.wall);
-      const auto tex_idx = (wall_val - 1) * 2 + (ray.x_facing ? 1u : 0u);
+      const auto tex_face = show_orientation_shading_ ? (ray.x_facing ? 1u : 0u) : 0u;
+      const auto tex_idx = (wall_val - 1) * 2 + tex_face;
 
       const auto proximity_shade = [&]() -> std::uint8_t {
-        if (!show_shading_) {
+        if (!show_proximity_shading_) {
           return 255u;
         }
         const auto raw = 1.0f - std::min(max_proximity_shadow, height_multiplier);
@@ -167,11 +171,10 @@ void RaycasterScene::draw_walls() const {
         r().fill_rect(wall_strip);
       }
     } else {
-      // Solid color matching the map overlay: use wall_color() + orientation shadow for E/W faces.
+      // Solid color: orientation and proximity shading are independent multipliers.
       const auto base_color = MapUtils::wall_color(ray.wall);
-      auto shadow = 1.0f;
-      if (show_shading_) {
-        shadow = ray.x_facing ? MapUtils::orientation_shadow_factor : 1.0f;
+      auto shadow = show_orientation_shading_ ? (ray.x_facing ? MapUtils::orientation_shadow_factor : 1.0f) : 1.0f;
+      if (show_proximity_shading_) {
         const auto raw = 1.0f - std::min(max_proximity_shadow, height_multiplier);
         const auto stepped = static_cast<float>(static_cast<int>(raw / step_size)) * step_size;
         shadow *= stepped;
@@ -189,8 +192,8 @@ void RaycasterScene::draw_help_overlay() const {
   constexpr auto ch = 8; // SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE
   constexpr auto line_h = ch + 4;
   constexpr auto padding = 6;
-  constexpr auto num_lines = 4;
-  constexpr auto max_chars = 18;
+  constexpr auto num_lines = 5;
+  constexpr auto max_chars = 22;
 
   float prev_sx{}, prev_sy{};
   SDL_GetRenderScale(sdl_r_, &prev_sx, &prev_sy);
@@ -211,13 +214,15 @@ void RaycasterScene::draw_help_overlay() const {
   SDL_SetRenderDrawColor(sdl_r_, 220, 220, 220, 255);
   const auto tx = bg_x + padding;
   auto ty = bg_y + padding;
-  SDL_RenderDebugText(sdl_r_, tx, ty, show_textures_ ? "T: Textures [on ]" : "T: Textures [off]");
+  SDL_RenderDebugText(sdl_r_, tx, ty, show_textures_ ? "T: Textures      [on ]" : "T: Textures      [off]");
   ty += line_h;
-  SDL_RenderDebugText(sdl_r_, tx, ty, show_shading_ ? "G: Shading  [on ]" : "G: Shading  [off]");
+  SDL_RenderDebugText(sdl_r_, tx, ty, show_proximity_shading_ ? "G: Prox shading  [on ]" : "G: Prox shading  [off]");
   ty += line_h;
-  SDL_RenderDebugText(sdl_r_, tx, ty, show_map_ ? "M: Map      [on ]" : "M: Map      [off]");
+  SDL_RenderDebugText(sdl_r_, tx, ty, show_orientation_shading_ ? "L: Orient shade  [on ]" : "L: Orient shade  [off]");
   ty += line_h;
-  SDL_RenderDebugText(sdl_r_, tx, ty, map_player_oriented_ ? "O: Map [player-up]" : "O: Map [north-up ]");
+  SDL_RenderDebugText(sdl_r_, tx, ty, show_map_ ? "M: Map           [on ]" : "M: Map           [off]");
+  ty += line_h;
+  SDL_RenderDebugText(sdl_r_, tx, ty, map_player_oriented_ ? "O: Map    [player-up]" : "O: Map     [north-up]");
 
   SDL_SetRenderScale(sdl_r_, prev_sx, prev_sy);
 }

--- a/wolf/wolf_raycaster/raycaster_scene.hpp
+++ b/wolf/wolf_raycaster/raycaster_scene.hpp
@@ -44,7 +44,8 @@ private:
   std::uint32_t last_timestamp_ms_{0u};
 
   bool show_textures_{true};
-  bool show_shading_{true};
+  bool show_proximity_shading_{true};
+  bool show_orientation_shading_{true};
   bool show_map_{true};
   bool map_player_oriented_{false};
 

--- a/wolf/wolf_raycaster/raycaster_scene.hpp
+++ b/wolf/wolf_raycaster/raycaster_scene.hpp
@@ -31,6 +31,7 @@ private:
   void init_wall_textures();
   void draw_background() const;
   void draw_walls() const;
+  void draw_help_overlay() const;
 
   const std::unique_ptr<const RawMap> raw_map_{};
   std::shared_ptr<const VswapFile> vswap_file_{};
@@ -44,7 +45,7 @@ private:
 
   bool show_textures_{true};
   bool show_shading_{true};
-  bool show_map_{false};
+  bool show_map_{true};
   bool map_player_oriented_{false};
 
   SDL_Renderer *sdl_r_{};

--- a/wolf/wolf_raycaster/raycaster_scene.hpp
+++ b/wolf/wolf_raycaster/raycaster_scene.hpp
@@ -2,8 +2,10 @@
 
 #include "raycaster.hpp"
 
+#include "wolf_common/map_renderer.hpp"
 #include "wolf_common/player_state.hpp"
 #include "wolf_common/raw_map.hpp"
+#include "wolf_common/vector_map.hpp"
 #include "wolf_common/vswap_file.hpp"
 
 #include <gp/sdl/scene_2d.hpp>
@@ -33,10 +35,17 @@ private:
   const std::unique_ptr<const RawMap> raw_map_{};
   std::shared_ptr<const VswapFile> vswap_file_{};
   PlayerState player_state_{*raw_map_};
+  VectorMap vector_map_{*raw_map_};
   Raycaster raycaster_;
+  MapRenderer map_renderer_;
   int width_{};
   int height_{};
   std::uint32_t last_timestamp_ms_{0u};
+
+  bool show_textures_{true};
+  bool show_shading_{true};
+  bool show_map_{false};
+  bool map_player_oriented_{false};
 
   SDL_Renderer *sdl_r_{};
   std::vector<std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)>> wall_textures_;


### PR DESCRIPTION
Closes #172
Closes #173
Closes #174
Closes #175

Adds four runtime toggles to `wolf_raycaster` via key presses:

| Key | Feature |
|-----|---------|
| **T** | Toggle textures on/off — solid `VectorMap` colors with orientation + proximity shading when off |
| **G** | Toggle proximity shading on/off |
| **M** | Toggle map overlay on/off — line-based overlay reusing `MapRenderer` from `wolf_common` |
| **O** | Toggle map orientation — north-up (player icon moves) vs player-up (map rotates around fixed player) |

Also adds `MapRenderer::set_player_oriented()` so orientation can be switched at runtime.