### PR TITLE
179: Fix WASM mouse performance by draining full event queue per frame

### DIFF
--- a/gp/sdl/internal/sdl_context.cpp
+++ b/gp/sdl/internal/sdl_context.cpp
@@ -77,107 +77,110 @@ int SDLContext::exec_loop(bool &quit_flag) const {
   int return_code = 0;
   SDL_Event sdl_event;
 
-  if (!SDL_PollEvent(&sdl_event)) {
-    const misc::Event redraw_event(misc::Event::Type::Redraw, timestamp());
-    forward_event_to_all_windows(redraw_event);
-    return return_code;
-  }
-
-  switch (sdl_event.type) {
-  case SDL_EVENT_QUIT: {
-    misc::Event event(misc::Event::Type::Quit, timestamp());
-    forward_event_to_all_windows(event);
-
-    quit_flag = true;
-  } break;
-  case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED: {
-    const auto wnd_id = sdl_event.window.windowID;
-    misc::Event event(misc::Event::Type::Resize, timestamp());
-    event.resize().width = sdl_event.window.data1;
-    event.resize().height = sdl_event.window.data2;
-    forward_event_to_window(wnd_id, event);
-  } break;
-  case SDL_EVENT_MOUSE_BUTTON_DOWN:
-  case SDL_EVENT_MOUSE_BUTTON_UP: {
-    const auto wnd_id = sdl_event.button.windowID;
-    misc::Event event(misc::Event::Type::MouseButton, timestamp());
+  while (SDL_PollEvent(&sdl_event)) {
     switch (sdl_event.type) {
+    case SDL_EVENT_QUIT: {
+      misc::Event event(misc::Event::Type::Quit, timestamp());
+      forward_event_to_all_windows(event);
+
+      quit_flag = true;
+    } break;
+    case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED: {
+      const auto wnd_id = sdl_event.window.windowID;
+      misc::Event event(misc::Event::Type::Resize, timestamp());
+      event.resize().width = sdl_event.window.data1;
+      event.resize().height = sdl_event.window.data2;
+      forward_event_to_window(wnd_id, event);
+    } break;
     case SDL_EVENT_MOUSE_BUTTON_DOWN:
-      event.mouse_button().action = misc::Event::Action::Pressed;
-      break;
-    case SDL_EVENT_MOUSE_BUTTON_UP:
-      event.mouse_button().action = misc::Event::Action::Released;
-      break;
-    default:
-      event.mouse_button().action = misc::Event::Action::None;
-      break;
-    }
-    switch (sdl_event.button.button) {
-    case SDL_BUTTON_LEFT:
-      event.mouse_button().button = misc::Event::MouseButton::Left;
-      break;
-    case SDL_BUTTON_MIDDLE:
-      event.mouse_button().button = misc::Event::MouseButton::Middle;
-      break;
-    case SDL_BUTTON_RIGHT:
-      event.mouse_button().button = misc::Event::MouseButton::Right;
-      break;
-    default:
-      event.mouse_button().button = misc::Event::MouseButton::None;
-      break;
-    }
-    forward_event_to_window(wnd_id, event);
-  } break;
-  case SDL_EVENT_MOUSE_MOTION: {
-    const auto wnd_id = sdl_event.motion.windowID;
-    misc::Event event(misc::Event::Type::MouseMove, timestamp());
-    event.mouse_move().x = sdl_event.motion.x;
-    event.mouse_move().y = sdl_event.motion.y;
-    event.mouse_move().x_rel = sdl_event.motion.xrel;
-    event.mouse_move().y_rel = sdl_event.motion.yrel;
-    event.mouse_move().mouse_button_mask = misc::Event::MouseButtonMask::None;
-    event.mouse_move().mouse_button_mask |=
-        (sdl_event.motion.state & SDL_BUTTON_LMASK) ? misc::Event::MouseButtonMask::Left : 0;
-    event.mouse_move().mouse_button_mask |=
-        (sdl_event.motion.state & SDL_BUTTON_MMASK) ? misc::Event::MouseButtonMask::Middle : 0;
-    event.mouse_move().mouse_button_mask |=
-        (sdl_event.motion.state & SDL_BUTTON_RMASK) ? misc::Event::MouseButtonMask::Right : 0;
-    forward_event_to_window(wnd_id, event);
-  } break;
-  case SDL_EVENT_MOUSE_WHEEL: {
-    const auto wnd_id = sdl_event.wheel.windowID;
-    misc::Event event(misc::Event::Type::MouseScroll, timestamp());
-    event.mouse_scroll().horizontal = sdl_event.wheel.x;
-    event.mouse_scroll().vertical = sdl_event.wheel.y;
-    forward_event_to_window(wnd_id, event);
-  } break;
-  case SDL_EVENT_KEY_DOWN:
-  case SDL_EVENT_KEY_UP: {
-    const auto wnd_id = sdl_event.key.windowID;
-    misc::Event event(misc::Event::Type::Key, timestamp());
-    switch (sdl_event.type) {
+    case SDL_EVENT_MOUSE_BUTTON_UP: {
+      const auto wnd_id = sdl_event.button.windowID;
+      misc::Event event(misc::Event::Type::MouseButton, timestamp());
+      switch (sdl_event.type) {
+      case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        event.mouse_button().action = misc::Event::Action::Pressed;
+        break;
+      case SDL_EVENT_MOUSE_BUTTON_UP:
+        event.mouse_button().action = misc::Event::Action::Released;
+        break;
+      default:
+        event.mouse_button().action = misc::Event::Action::None;
+        break;
+      }
+      switch (sdl_event.button.button) {
+      case SDL_BUTTON_LEFT:
+        event.mouse_button().button = misc::Event::MouseButton::Left;
+        break;
+      case SDL_BUTTON_MIDDLE:
+        event.mouse_button().button = misc::Event::MouseButton::Middle;
+        break;
+      case SDL_BUTTON_RIGHT:
+        event.mouse_button().button = misc::Event::MouseButton::Right;
+        break;
+      default:
+        event.mouse_button().button = misc::Event::MouseButton::None;
+        break;
+      }
+      forward_event_to_window(wnd_id, event);
+    } break;
+    case SDL_EVENT_MOUSE_MOTION: {
+      const auto wnd_id = sdl_event.motion.windowID;
+      misc::Event event(misc::Event::Type::MouseMove, timestamp());
+      event.mouse_move().x = sdl_event.motion.x;
+      event.mouse_move().y = sdl_event.motion.y;
+      event.mouse_move().x_rel = sdl_event.motion.xrel;
+      event.mouse_move().y_rel = sdl_event.motion.yrel;
+      event.mouse_move().mouse_button_mask = misc::Event::MouseButtonMask::None;
+      event.mouse_move().mouse_button_mask |=
+          (sdl_event.motion.state & SDL_BUTTON_LMASK) ? misc::Event::MouseButtonMask::Left : 0;
+      event.mouse_move().mouse_button_mask |=
+          (sdl_event.motion.state & SDL_BUTTON_MMASK) ? misc::Event::MouseButtonMask::Middle : 0;
+      event.mouse_move().mouse_button_mask |=
+          (sdl_event.motion.state & SDL_BUTTON_RMASK) ? misc::Event::MouseButtonMask::Right : 0;
+      forward_event_to_window(wnd_id, event);
+    } break;
+    case SDL_EVENT_MOUSE_WHEEL: {
+      const auto wnd_id = sdl_event.wheel.windowID;
+      misc::Event event(misc::Event::Type::MouseScroll, timestamp());
+      event.mouse_scroll().horizontal = sdl_event.wheel.x;
+      event.mouse_scroll().vertical = sdl_event.wheel.y;
+      forward_event_to_window(wnd_id, event);
+    } break;
     case SDL_EVENT_KEY_DOWN:
-      event.key().action = misc::Event::Action::Pressed;
-      break;
-    case SDL_EVENT_KEY_UP:
-      event.key().action = misc::Event::Action::Released;
-      break;
+    case SDL_EVENT_KEY_UP: {
+      const auto wnd_id = sdl_event.key.windowID;
+      misc::Event event(misc::Event::Type::Key, timestamp());
+      switch (sdl_event.type) {
+      case SDL_EVENT_KEY_DOWN:
+        event.key().action = misc::Event::Action::Pressed;
+        break;
+      case SDL_EVENT_KEY_UP:
+        event.key().action = misc::Event::Action::Released;
+        break;
+      default:
+        event.key().action = misc::Event::Action::None;
+        break;
+      }
+      event.key().scan_code = to_scan_code(sdl_event.key.scancode);
+      forward_event_to_window(wnd_id, event);
+    } break;
+    case SDL_EVENT_DROP_FILE: {
+      const auto wnd_id = sdl_event.drop.windowID;
+      misc::Event event(misc::Event::Type::DragDrop, timestamp());
+      event.drag_drop().filepath = sdl_event.drop.data;
+      forward_event_to_window(wnd_id, event);
+    } break;
     default:
-      event.key().action = misc::Event::Action::None;
       break;
     }
-    event.key().scan_code = to_scan_code(sdl_event.key.scancode);
-    forward_event_to_window(wnd_id, event);
-  } break;
-  case SDL_EVENT_DROP_FILE: {
-    const auto wnd_id = sdl_event.drop.windowID;
-    misc::Event event(misc::Event::Type::DragDrop, timestamp());
-    event.drag_drop().filepath = sdl_event.drop.data;
-    forward_event_to_window(wnd_id, event);
-  } break;
-  default:
-    break;
+
+    if (quit_flag) {
+      return return_code;
+    }
   }
+
+  const misc::Event redraw_event(misc::Event::Type::Redraw, timestamp());
+  forward_event_to_all_windows(redraw_event);
 
   return return_code;
 }


### PR DESCRIPTION
Fixes #179

## Root cause

## Fix
Changed `if` to `while` so all pending SDL events are drained in a single `exec_loop` call. A `Redraw` event is then sent unconditionally at the end of every frame (unless quitting). This aligns behaviour between native and WASM builds.