### PR TITLE
183: Preprocess visible walls to fix noclip 1x1 room effect

### DIFF
--- a/wolf/wolf_common/raw_map.cpp
+++ b/wolf/wolf_common/raw_map.cpp
@@ -1,5 +1,7 @@
 #include "raw_map.hpp"
 
+#include <array>
+#include <queue>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -37,6 +39,7 @@ RawMap::RawMap(const int width, const int height, std::vector<BlockType> &&block
   process_doors();
   process_ambush_tiles();
   process_start_position();
+  process_visible_walls();
 }
 
 int RawMap::width() const { return size_.x; }
@@ -66,12 +69,10 @@ bool RawMap::is_within_bounds(const glm::ivec2 &pos) const {
 bool RawMap::is_wall(const int w, const int h) const { return is_wall(glm::ivec2{w, h}); }
 
 bool RawMap::is_wall(const glm::ivec2 &pos) const {
-  if (!is_within_bounds(pos)) {
+  if (!is_wall_raw(pos)) {
     return false;
   }
-
-  const auto wall = block(pos.x, pos.y).wall;
-  return wall > Map::Walls::nothing && wall < Map::Walls::elevator_to_secret_floor;
+  return visible_walls_[static_cast<std::size_t>(pos.x + pos.y * width())];
 }
 
 const glm::ivec2 &RawMap::player_pos() const { return player_pos_; }
@@ -82,6 +83,55 @@ RawMap::BlockType &RawMap::block(const int w, const int h) {
   }
 
   return blocks_[w + h * width()];
+}
+
+bool RawMap::is_wall_raw(const glm::ivec2 &pos) const {
+  if (!is_within_bounds(pos)) {
+    return false;
+  }
+  const auto wall = block(pos.x, pos.y).wall;
+  return wall > Map::Walls::nothing && wall < Map::Walls::elevator_to_secret_floor;
+}
+
+void RawMap::process_visible_walls() {
+  const auto sz = static_cast<std::size_t>(width() * height());
+  visible_walls_.assign(sz, false);
+
+  std::vector<bool> visited(sz, false);
+  std::queue<glm::ivec2> queue;
+
+  const auto start_idx = static_cast<std::size_t>(player_pos_.x + player_pos_.y * width());
+  visited[start_idx] = true;
+  queue.push(player_pos_);
+
+  constexpr std::array<glm::ivec2, 4> dirs = {
+      glm::ivec2{ 0, -1},
+      glm::ivec2{ 0,  1},
+      glm::ivec2{-1,  0},
+      glm::ivec2{ 1,  0}
+  };
+
+  while (!queue.empty()) {
+    const auto curr = queue.front();
+    queue.pop();
+
+    for (const auto &dir : dirs) {
+      const auto next = curr + dir;
+      if (!is_within_bounds(next)) {
+        continue;
+      }
+      const auto next_idx = static_cast<std::size_t>(next.x + next.y * width());
+      if (visited[next_idx]) {
+        continue;
+      }
+      visited[next_idx] = true;
+      if (is_wall_raw(next)) {
+        visible_walls_[next_idx] = true;
+      } else {
+        queue.push(next);
+      }
+    }
+  }
 }
 
 void RawMap::process_doors() {

--- a/wolf/wolf_common/raw_map.cpp
+++ b/wolf/wolf_common/raw_map.cpp
@@ -1,5 +1,6 @@
 #include "raw_map.hpp"
 
+#include <array>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -37,6 +38,7 @@ RawMap::RawMap(const int width, const int height, std::vector<BlockType> &&block
   process_doors();
   process_ambush_tiles();
   process_start_position();
+  process_corridor_walls();
 }
 
 int RawMap::width() const { return size_.x; }
@@ -70,8 +72,7 @@ bool RawMap::is_wall(const glm::ivec2 &pos) const {
     return false;
   }
 
-  const auto wall = block(pos.x, pos.y).wall;
-  return wall > Map::Walls::nothing && wall < Map::Walls::elevator_to_secret_floor;
+  return corridor_walls_[static_cast<std::size_t>(pos.x + pos.y * width())];
 }
 
 const glm::ivec2 &RawMap::player_pos() const { return player_pos_; }
@@ -82,6 +83,40 @@ RawMap::BlockType &RawMap::block(const int w, const int h) {
   }
 
   return blocks_[w + h * width()];
+}
+
+bool RawMap::is_wall_raw(const glm::ivec2 &pos) const {
+  if (!is_within_bounds(pos)) {
+    return false;
+  }
+  const auto wall = block(pos.x, pos.y).wall;
+  return wall > Map::Walls::nothing && wall < Map::Walls::elevator_to_secret_floor;
+}
+
+void RawMap::process_corridor_walls() {
+  corridor_walls_.assign(static_cast<std::size_t>(width() * height()), false);
+
+  constexpr std::array<glm::ivec2, 4> dirs = {
+      glm::ivec2{ 0, -1},
+      glm::ivec2{ 0,  1},
+      glm::ivec2{-1,  0},
+      glm::ivec2{ 1,  0}
+  };
+
+  for (auto h = 0; h < height(); ++h) {
+    for (auto w = 0; w < width(); ++w) {
+      if (!is_wall_raw({w, h})) {
+        continue;
+      }
+      for (const auto &dir : dirs) {
+        const auto neighbor = glm::ivec2{w, h} + dir;
+        if (is_within_bounds(neighbor) && !is_wall_raw(neighbor)) {
+          corridor_walls_[static_cast<std::size_t>(w + h * width())] = true;
+          break;
+        }
+      }
+    }
+  }
 }
 
 void RawMap::process_doors() {

--- a/wolf/wolf_common/raw_map.cpp
+++ b/wolf/wolf_common/raw_map.cpp
@@ -1,7 +1,5 @@
 #include "raw_map.hpp"
 
-#include <array>
-#include <queue>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -39,7 +37,6 @@ RawMap::RawMap(const int width, const int height, std::vector<BlockType> &&block
   process_doors();
   process_ambush_tiles();
   process_start_position();
-  process_visible_walls();
 }
 
 int RawMap::width() const { return size_.x; }
@@ -69,10 +66,12 @@ bool RawMap::is_within_bounds(const glm::ivec2 &pos) const {
 bool RawMap::is_wall(const int w, const int h) const { return is_wall(glm::ivec2{w, h}); }
 
 bool RawMap::is_wall(const glm::ivec2 &pos) const {
-  if (!is_wall_raw(pos)) {
+  if (!is_within_bounds(pos)) {
     return false;
   }
-  return visible_walls_[static_cast<std::size_t>(pos.x + pos.y * width())];
+
+  const auto wall = block(pos.x, pos.y).wall;
+  return wall > Map::Walls::nothing && wall < Map::Walls::elevator_to_secret_floor;
 }
 
 const glm::ivec2 &RawMap::player_pos() const { return player_pos_; }
@@ -83,55 +82,6 @@ RawMap::BlockType &RawMap::block(const int w, const int h) {
   }
 
   return blocks_[w + h * width()];
-}
-
-bool RawMap::is_wall_raw(const glm::ivec2 &pos) const {
-  if (!is_within_bounds(pos)) {
-    return false;
-  }
-  const auto wall = block(pos.x, pos.y).wall;
-  return wall > Map::Walls::nothing && wall < Map::Walls::elevator_to_secret_floor;
-}
-
-void RawMap::process_visible_walls() {
-  const auto sz = static_cast<std::size_t>(width() * height());
-  visible_walls_.assign(sz, false);
-
-  std::vector<bool> visited(sz, false);
-  std::queue<glm::ivec2> queue;
-
-  const auto start_idx = static_cast<std::size_t>(player_pos_.x + player_pos_.y * width());
-  visited[start_idx] = true;
-  queue.push(player_pos_);
-
-  constexpr std::array<glm::ivec2, 4> dirs = {
-      glm::ivec2{ 0, -1},
-      glm::ivec2{ 0,  1},
-      glm::ivec2{-1,  0},
-      glm::ivec2{ 1,  0}
-  };
-
-  while (!queue.empty()) {
-    const auto curr = queue.front();
-    queue.pop();
-
-    for (const auto &dir : dirs) {
-      const auto next = curr + dir;
-      if (!is_within_bounds(next)) {
-        continue;
-      }
-      const auto next_idx = static_cast<std::size_t>(next.x + next.y * width());
-      if (visited[next_idx]) {
-        continue;
-      }
-      visited[next_idx] = true;
-      if (is_wall_raw(next)) {
-        visible_walls_[next_idx] = true;
-      } else {
-        queue.push(next);
-      }
-    }
-  }
 }
 
 void RawMap::process_doors() {

--- a/wolf/wolf_common/raw_map.hpp
+++ b/wolf/wolf_common/raw_map.hpp
@@ -39,16 +39,12 @@ private:
   glm::ivec2 size_{-1, -1};
 
   std::vector<BlockType> blocks_{};
-  std::vector<bool> visible_walls_{};
   glm::ivec2 player_pos_{-1, -1};
 
   BlockType &block(const int w, const int h);
 
-  bool is_wall_raw(const glm::ivec2 &pos) const;
-
   void process_doors();
   void process_ambush_tiles();
   void process_start_position();
-  void process_visible_walls();
 };
 } // namespace wolf

--- a/wolf/wolf_common/raw_map.hpp
+++ b/wolf/wolf_common/raw_map.hpp
@@ -39,12 +39,16 @@ private:
   glm::ivec2 size_{-1, -1};
 
   std::vector<BlockType> blocks_{};
+  std::vector<bool> visible_walls_{};
   glm::ivec2 player_pos_{-1, -1};
 
   BlockType &block(const int w, const int h);
 
+  bool is_wall_raw(const glm::ivec2 &pos) const;
+
   void process_doors();
   void process_ambush_tiles();
   void process_start_position();
+  void process_visible_walls();
 };
 } // namespace wolf

--- a/wolf/wolf_common/raw_map.hpp
+++ b/wolf/wolf_common/raw_map.hpp
@@ -39,12 +39,16 @@ private:
   glm::ivec2 size_{-1, -1};
 
   std::vector<BlockType> blocks_{};
+  std::vector<bool> corridor_walls_{};
   glm::ivec2 player_pos_{-1, -1};
 
   BlockType &block(const int w, const int h);
 
+  bool is_wall_raw(const glm::ivec2 &pos) const;
+
   void process_doors();
   void process_ambush_tiles();
   void process_start_position();
+  void process_corridor_walls();
 };
 } // namespace wolf


### PR DESCRIPTION
## Summary

Fixes #183.

When noclip mode moves the player into a filler wall block (or outside the map boundary), the raycaster saw wall blocks in every direction, producing a "1x1 room" effect.

## Changes

**`wolf_common/raw_map.cpp` / `raw_map.hpp`:**

- Added `process_visible_walls()` — called once at the end of the `RawMap` constructor after all other preprocessing steps.
  - BFS flood-fill from the player start position across all non-wall (floor) blocks.
  - Marks a wall block as *visible* if and only if it is directly adjacent (4-directional) to at least one reachable floor cell.
  - Result is stored in `visible_walls_` — a `std::vector<bool>` the same size as the map.
- Extracted `is_wall_raw()` — the original wall check without the visibility filter, used internally by the BFS to avoid a circular dependency.
- Modified `is_wall()` — now returns `false` for any wall not present in `visible_walls_`, so the raycaster transparently skips filler blocks.