### PR TITLE
188: Add per-frame pipeline timing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ CMakeUserPresets.json
 
 # Compile commands
 compile_commands.json
+
+# Streaming benchmark logs
+benchmark_logs/

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -23,7 +23,7 @@ case "${1:-}" in
     COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-    LOG_FILE="${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
+    LOG_FILE="$(pwd)/${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
     {
       printf "# streaming pipeline stats\n"
       printf "# date:   %s\n" "$(date)"

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -6,8 +6,9 @@
 #   ./run_streaming.sh receiver [extra args]
 #
 # The receiver creates a timestamped session folder in benchmark_logs/ and
-# updates a "latest" symlink. The streamer writes into that same session folder
-# automatically (start receiver before or at the same time as streamer).
+# writes its path to benchmark_logs/.current. The streamer discovers this
+# file lazily (on first stats flush) and writes streamer.log there.
+# Start the receiver before or alongside the streamer.
 
 set -euo pipefail
 
@@ -21,16 +22,8 @@ case "${1:-}" in
     ;;
 
   streamer)
-    # Write into the latest session folder created by the receiver
-    SESSION_DIR="${BASE_LOG_DIR}/latest"
-    if [[ ! -d "$SESSION_DIR" ]]; then
-      echo "No active session folder found (run receiver first, or start them together)."
-      echo "Falling back to stdout for stats."
-      exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" "${@:2}"
-    fi
-    LOG_FILE="${SESSION_DIR}/streamer.log"
     exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" \
-      --stats-log "${LOG_FILE}" "${@:2}"
+      --stats-log-dir "${BASE_LOG_DIR}" "${@:2}"
     ;;
 
   receiver)
@@ -39,8 +32,8 @@ case "${1:-}" in
     SESSION_DIR="${BASE_LOG_DIR}/${TIMESTAMP}_${BRANCH}"
     mkdir -p "$SESSION_DIR"
 
-    # Update "latest" symlink
-    ln -sfn "$SESSION_DIR" "${BASE_LOG_DIR}/latest"
+    # Record current session path for streamer to discover
+    printf "%s\n" "$SESSION_DIR" > "${BASE_LOG_DIR}/.current"
 
     # Write session metadata
     {

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -4,54 +4,58 @@
 #   ./run_streaming.sh server   [extra args]
 #   ./run_streaming.sh streamer [extra args]
 #   ./run_streaming.sh receiver [extra args]
+#
+# The receiver creates a timestamped session folder in benchmark_logs/ and
+# updates a "latest" symlink. The streamer writes into that same session folder
+# automatically (start receiver before or at the same time as streamer).
 
 set -euo pipefail
 
 PRESET=${STREAMING_PRESET:-ninja}
 BUILD_DIR="build/${PRESET}/streaming"
+BASE_LOG_DIR="$(pwd)/benchmark_logs"
 
 case "${1:-}" in
   server)
     exec "${BUILD_DIR}/streaming_signaling_server/Release/streaming_signaling_server" "${@:2}"
     ;;
+
   streamer)
-    LOG_DIR="benchmark_logs"
-    mkdir -p "$LOG_DIR"
-    COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
-    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
-    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-    LOG_FILE="$(pwd)/${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}_encode.log"
-    {
-      printf "# streaming pipeline stats (encode)\n"
-      printf "# date:   %s\n" "$(date)"
-      printf "# commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-      printf "# branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-      printf "# preset: %s\n" "$PRESET"
-      printf "#\n"
-    } > "$LOG_FILE"
-    echo "Stats log: ${LOG_FILE}"
+    # Write into the latest session folder created by the receiver
+    SESSION_DIR="${BASE_LOG_DIR}/latest"
+    if [[ ! -d "$SESSION_DIR" ]]; then
+      echo "No active session folder found (run receiver first, or start them together)."
+      echo "Falling back to stdout for stats."
+      exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" "${@:2}"
+    fi
+    LOG_FILE="${SESSION_DIR}/streamer.log"
     exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" \
       --stats-log "${LOG_FILE}" "${@:2}"
     ;;
+
   receiver)
-    LOG_DIR="benchmark_logs"
-    mkdir -p "$LOG_DIR"
     COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-    LOG_FILE="$(pwd)/${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}_decode.log"
+    SESSION_DIR="${BASE_LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}"
+    mkdir -p "$SESSION_DIR"
+
+    # Update "latest" symlink
+    ln -sfn "$SESSION_DIR" "${BASE_LOG_DIR}/latest"
+
+    # Write session metadata
     {
-      printf "# streaming pipeline stats (decode)\n"
-      printf "# date:   %s\n" "$(date)"
-      printf "# commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-      printf "# branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-      printf "# preset: %s\n" "$PRESET"
-      printf "#\n"
-    } > "$LOG_FILE"
-    echo "Stats log: ${LOG_FILE}"
+      printf "date:   %s\n" "$(date)"
+      printf "commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+      printf "branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+      printf "preset: %s\n" "$PRESET"
+    } > "${SESSION_DIR}/info.log"
+
+    echo "Session: ${SESSION_DIR}"
     exec "${BUILD_DIR}/streaming_receiver/Release/streaming_receiver" \
-      --stats-log "${LOG_FILE}" "${@:2}"
+      --stats-log "${SESSION_DIR}/receiver.log" "${@:2}"
     ;;
+
   *)
     echo "Usage: $0 {server|streamer|receiver} [extra args]"
     exit 1

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -15,7 +15,23 @@ case "${1:-}" in
     exec "${BUILD_DIR}/streaming_signaling_server/Release/streaming_signaling_server" "${@:2}"
     ;;
   streamer)
-    exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" "${@:2}"
+    LOG_DIR="benchmark_logs"
+    mkdir -p "$LOG_DIR"
+    COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
+    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
+    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+    LOG_FILE="$(pwd)/${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}_encode.log"
+    {
+      printf "# streaming pipeline stats (encode)\n"
+      printf "# date:   %s\n" "$(date)"
+      printf "# commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+      printf "# branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+      printf "# preset: %s\n" "$PRESET"
+      printf "#\n"
+    } > "$LOG_FILE"
+    echo "Stats log: ${LOG_FILE}"
+    exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" \
+      --stats-log "${LOG_FILE}" "${@:2}"
     ;;
   receiver)
     LOG_DIR="benchmark_logs"
@@ -23,9 +39,9 @@ case "${1:-}" in
     COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-    LOG_FILE="$(pwd)/${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
+    LOG_FILE="$(pwd)/${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}_decode.log"
     {
-      printf "# streaming pipeline stats\n"
+      printf "# streaming pipeline stats (decode)\n"
       printf "# date:   %s\n" "$(date)"
       printf "# commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
       printf "# branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
-# Streaming runner.
+# Streaming runner / benchmark.
 # Starts signaling server, streamer, and receiver.
-# When STREAMING_PIPELINE_STATS is enabled (default), pipeline stats are written
-# to a timestamped log file in benchmark_logs/ instead of stdout.
+# The receiver auto-closes after REPORTS stat cycles and writes stats to a
+# timestamped log file in benchmark_logs/.
 #
 # Usage:
 #   ./run_streaming.sh
+#   REPORTS=10 ./run_streaming.sh
 #   STREAMING_PRESET=ninja_debug ./run_streaming.sh
 
 set -uo pipefail
 
 PRESET=${STREAMING_PRESET:-ninja}
+REPORTS=${REPORTS:-20}
 
 BUILD_DIR="build/${PRESET}/streaming"
 SERVER="${BUILD_DIR}/streaming_signaling_server/Release/streaming_signaling_server"
@@ -35,36 +37,45 @@ LOG_FILE="${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
 
 {
   printf "# streaming pipeline stats\n"
-  printf "# date:   %s\n" "$(date)"
-  printf "# commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-  printf "# branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-  printf "# preset: %s\n" "$PRESET"
+  printf "# date:    %s\n" "$(date)"
+  printf "# commit:  %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  printf "# branch:  %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+  printf "# preset:  %s\n" "$PRESET"
+  printf "# reports: %s x 100 frames\n" "$REPORTS"
   printf "#\n"
 } > "$LOG_FILE"
 
-echo "Stats log: ${LOG_FILE}"
+echo "Stats log:  ${LOG_FILE}"
+echo "Reports:    ${REPORTS} x 100 frames"
 echo
 
-# --- Cleanup ---
+# --- Cleanup: kill all on exit / Ctrl-C ---
 SERVER_PID="" STREAMER_PID="" RECEIVER_PID=""
 cleanup() {
-  kill "$SERVER_PID" "$STREAMER_PID" "$RECEIVER_PID" 2>/dev/null || true
+  for pid in "$SERVER_PID" "$STREAMER_PID" "$RECEIVER_PID"; do
+    if [[ -n "$pid" ]]; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
   wait 2>/dev/null || true
   echo ""
-  echo "Log: ${LOG_FILE}"
+  echo "Done. Log: ${LOG_FILE}"
 }
 trap cleanup EXIT INT TERM
 
-# --- Launch ---
-"${SERVER}" 2>&1 | sed 's/^/[server  ] /' &
+# Launch server — show its minimal output; capture real PID
+"${SERVER}" &
 SERVER_PID=$!
 sleep 0.5
 
-"${STREAMER}" 2>&1 | sed 's/^/[streamer] /' &
+# Launch streamer — suppress FFmpeg noise (stats go to file)
+"${STREAMER}" 2>/dev/null &
 STREAMER_PID=$!
 
-"${RECEIVER}" --stats-log "${LOG_FILE}" 2>&1 | sed 's/^/[receiver] /' &
+# Launch receiver — suppress FFmpeg noise; stats written directly to LOG_FILE
+"${RECEIVER}" --stats-log "${LOG_FILE}" --stats-reports "${REPORTS}" 2>/dev/null &
 RECEIVER_PID=$!
 
-echo "All processes started. Press Ctrl-C to stop."
-wait "$RECEIVER_PID"
+echo "All processes started (Ctrl-C to stop early)."
+# Wait for receiver to auto-close after N reports
+wait "$RECEIVER_PID" || true

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -1,81 +1,43 @@
 #!/usr/bin/env bash
-# Streaming runner / benchmark.
-# Starts signaling server, streamer, and receiver.
-# The receiver auto-closes after REPORTS stat cycles and writes stats to a
-# timestamped log file in benchmark_logs/.
-#
+# Streaming launcher.
 # Usage:
-#   ./run_streaming.sh
-#   REPORTS=10 ./run_streaming.sh
-#   STREAMING_PRESET=ninja_debug ./run_streaming.sh
+#   ./run_streaming.sh server   [extra args]
+#   ./run_streaming.sh streamer [extra args]
+#   ./run_streaming.sh receiver [extra args]
 
-set -uo pipefail
+set -euo pipefail
 
 PRESET=${STREAMING_PRESET:-ninja}
-REPORTS=${REPORTS:-20}
-
 BUILD_DIR="build/${PRESET}/streaming"
-SERVER="${BUILD_DIR}/streaming_signaling_server/Release/streaming_signaling_server"
-STREAMER="${BUILD_DIR}/streaming_streamer/Release/streaming_streamer"
-RECEIVER="${BUILD_DIR}/streaming_receiver/Release/streaming_receiver"
 
-for bin in "$SERVER" "$STREAMER" "$RECEIVER"; do
-  if [[ ! -x "$bin" ]]; then
-    echo "Binary not found: $bin"
-    echo "Build first:  cmake --build --preset=${PRESET}"
+case "${1:-}" in
+  server)
+    exec "${BUILD_DIR}/streaming_signaling_server/Release/streaming_signaling_server" "${@:2}"
+    ;;
+  streamer)
+    exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" "${@:2}"
+    ;;
+  receiver)
+    LOG_DIR="benchmark_logs"
+    mkdir -p "$LOG_DIR"
+    COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
+    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
+    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+    LOG_FILE="${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
+    {
+      printf "# streaming pipeline stats\n"
+      printf "# date:   %s\n" "$(date)"
+      printf "# commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+      printf "# branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+      printf "# preset: %s\n" "$PRESET"
+      printf "#\n"
+    } > "$LOG_FILE"
+    echo "Stats log: ${LOG_FILE}"
+    exec "${BUILD_DIR}/streaming_receiver/Release/streaming_receiver" \
+      --stats-log "${LOG_FILE}" "${@:2}"
+    ;;
+  *)
+    echo "Usage: $0 {server|streamer|receiver} [extra args]"
     exit 1
-  fi
-done
-
-# --- Log file for pipeline stats ---
-LOG_DIR="benchmark_logs"
-mkdir -p "$LOG_DIR"
-COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-LOG_FILE="${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
-
-{
-  printf "# streaming pipeline stats\n"
-  printf "# date:    %s\n" "$(date)"
-  printf "# commit:  %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-  printf "# branch:  %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-  printf "# preset:  %s\n" "$PRESET"
-  printf "# reports: %s x 100 frames\n" "$REPORTS"
-  printf "#\n"
-} > "$LOG_FILE"
-
-echo "Stats log:  ${LOG_FILE}"
-echo "Reports:    ${REPORTS} x 100 frames"
-echo
-
-# --- Cleanup: kill all on exit / Ctrl-C ---
-SERVER_PID="" STREAMER_PID="" RECEIVER_PID=""
-cleanup() {
-  for pid in "$SERVER_PID" "$STREAMER_PID" "$RECEIVER_PID"; do
-    if [[ -n "$pid" ]]; then
-      kill "$pid" 2>/dev/null || true
-    fi
-  done
-  wait 2>/dev/null || true
-  echo ""
-  echo "Done. Log: ${LOG_FILE}"
-}
-trap cleanup EXIT INT TERM
-
-# Launch server — show output directly
-"${SERVER}" &
-SERVER_PID=$!
-sleep 0.5
-
-# Launch streamer — show output (FFmpeg warnings are useful for debugging)
-"${STREAMER}" &
-STREAMER_PID=$!
-
-# Launch receiver — stats written to LOG_FILE; suppress FFmpeg noise on stderr
-"${RECEIVER}" --stats-log "${LOG_FILE}" --stats-reports "${REPORTS}" 2>/dev/null &
-RECEIVER_PID=$!
-
-echo "All processes started (Ctrl-C to stop early)."
-# Wait for receiver to auto-close after N reports
-wait "$RECEIVER_PID" || true
+    ;;
+esac

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
-# Streaming benchmark runner.
-# Runs signaling server, streamer, and receiver for a fixed duration,
-# collecting pipeline timing-stat reports and saving everything to a log file.
+# Streaming runner.
+# Starts signaling server, streamer, and receiver.
+# When STREAMING_PIPELINE_STATS is enabled (default), pipeline stats are written
+# to a timestamped log file in benchmark_logs/ instead of stdout.
 #
 # Usage:
 #   ./run_streaming.sh
-#   REPORTS=30 ./run_streaming.sh
-#   FPS=60 STREAMING_PRESET=ninja_debug ./run_streaming.sh
+#   STREAMING_PRESET=ninja_debug ./run_streaming.sh
 
 set -uo pipefail
 
 PRESET=${STREAMING_PRESET:-ninja}
-REPORTS=${REPORTS:-20}
-REPORT_INTERVAL=100  # must match PIPELINE_STATS_REPORT_INTERVAL in pipeline_stats.hpp
-FPS=${FPS:-30}
 
 BUILD_DIR="build/${PRESET}/streaming"
 SERVER="${BUILD_DIR}/streaming_signaling_server/Release/streaming_signaling_server"
@@ -28,7 +25,7 @@ for bin in "$SERVER" "$STREAMER" "$RECEIVER"; do
   fi
 done
 
-# --- Log file ---
+# --- Log file for pipeline stats ---
 LOG_DIR="benchmark_logs"
 mkdir -p "$LOG_DIR"
 COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
@@ -36,24 +33,16 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 LOG_FILE="${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
 
-# Duration: enough frames for all requested reports + startup buffer
-DURATION=$(( REPORTS * REPORT_INTERVAL / FPS + 15 ))
-
 {
-  printf "# streaming benchmark\n"
-  printf "# date:    %s\n" "$(date)"
-  printf "# commit:  %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-  printf "# branch:  %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-  printf "# preset:  %s\n" "$PRESET"
-  printf "# target:  %d reports x %d frames @ %d fps (~%ds)\n" \
-         "$REPORTS" "$REPORT_INTERVAL" "$FPS" "$DURATION"
+  printf "# streaming pipeline stats\n"
+  printf "# date:   %s\n" "$(date)"
+  printf "# commit: %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  printf "# branch: %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+  printf "# preset: %s\n" "$PRESET"
   printf "#\n"
 } > "$LOG_FILE"
 
-echo "Streaming benchmark"
-echo "  reports:  ${REPORTS} x ${REPORT_INTERVAL} frames @ ${FPS} fps"
-echo "  duration: ~${DURATION}s"
-echo "  log:      ${LOG_FILE}"
+echo "Stats log: ${LOG_FILE}"
 echo
 
 # --- Cleanup ---
@@ -62,19 +51,20 @@ cleanup() {
   kill "$SERVER_PID" "$STREAMER_PID" "$RECEIVER_PID" 2>/dev/null || true
   wait 2>/dev/null || true
   echo ""
-  echo "Benchmark done. Log: ${LOG_FILE}"
+  echo "Log: ${LOG_FILE}"
 }
 trap cleanup EXIT INT TERM
 
-# --- Launch (each pipeline: app → prefix → tee to terminal + log) ---
-"${SERVER}"   2>&1 | sed 's/^/[server  ] /' | tee -a "$LOG_FILE" &
+# --- Launch ---
+"${SERVER}" 2>&1 | sed 's/^/[server  ] /' &
 SERVER_PID=$!
 sleep 0.5
 
-"${STREAMER}" 2>&1 | sed 's/^/[streamer] /' | tee -a "$LOG_FILE" &
+"${STREAMER}" 2>&1 | sed 's/^/[streamer] /' &
 STREAMER_PID=$!
 
-"${RECEIVER}" 2>&1 | sed 's/^/[receiver] /' | tee -a "$LOG_FILE" &
+"${RECEIVER}" --stats-log "${LOG_FILE}" 2>&1 | sed 's/^/[receiver] /' &
 RECEIVER_PID=$!
 
-sleep "$DURATION"
+echo "All processes started. Press Ctrl-C to stop."
+wait "$RECEIVER_PID"

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -34,10 +34,9 @@ case "${1:-}" in
     ;;
 
   receiver)
-    COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-    SESSION_DIR="${BASE_LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}"
+    SESSION_DIR="${BASE_LOG_DIR}/${TIMESTAMP}_${BRANCH}"
     mkdir -p "$SESSION_DIR"
 
     # Update "latest" symlink

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -6,9 +6,8 @@
 #   ./run_streaming.sh receiver [extra args]
 #
 # The receiver creates a timestamped session folder in benchmark_logs/ and
-# writes its path to benchmark_logs/.current. The streamer discovers this
-# file lazily (on first stats flush) and writes streamer.log there.
-# Start the receiver before or alongside the streamer.
+# records its path in benchmark_logs/.current. The streamer reads .current
+# and receives the same path as --stats-log. Start the receiver first.
 
 set -euo pipefail
 
@@ -22,8 +21,13 @@ case "${1:-}" in
     ;;
 
   streamer)
+    SESSION_DIR=$(cat "${BASE_LOG_DIR}/.current" 2>/dev/null | tr -d '[:space:]')
+    if [[ -z "$SESSION_DIR" ]]; then
+      echo "No active session found. Start the receiver first."
+      exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" "${@:2}"
+    fi
     exec "${BUILD_DIR}/streaming_streamer/Release/streaming_streamer" \
-      --stats-log-dir "${BASE_LOG_DIR}" "${@:2}"
+      --stats-log "${SESSION_DIR}/streamer.log" "${@:2}"
     ;;
 
   receiver)

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -63,16 +63,16 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Launch server — show its minimal output; capture real PID
+# Launch server — show output directly
 "${SERVER}" &
 SERVER_PID=$!
 sleep 0.5
 
-# Launch streamer — suppress FFmpeg noise (stats go to file)
-"${STREAMER}" 2>/dev/null &
+# Launch streamer — show output (FFmpeg warnings are useful for debugging)
+"${STREAMER}" &
 STREAMER_PID=$!
 
-# Launch receiver — suppress FFmpeg noise; stats written directly to LOG_FILE
+# Launch receiver — stats written to LOG_FILE; suppress FFmpeg noise on stderr
 "${RECEIVER}" --stats-log "${LOG_FILE}" --stats-reports "${REPORTS}" 2>/dev/null &
 RECEIVER_PID=$!
 

--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Streaming benchmark runner.
+# Runs signaling server, streamer, and receiver for a fixed duration,
+# collecting pipeline timing-stat reports and saving everything to a log file.
+#
+# Usage:
+#   ./run_streaming.sh
+#   REPORTS=30 ./run_streaming.sh
+#   FPS=60 STREAMING_PRESET=ninja_debug ./run_streaming.sh
+
+set -uo pipefail
+
+PRESET=${STREAMING_PRESET:-ninja}
+REPORTS=${REPORTS:-20}
+REPORT_INTERVAL=100  # must match PIPELINE_STATS_REPORT_INTERVAL in pipeline_stats.hpp
+FPS=${FPS:-30}
+
+BUILD_DIR="build/${PRESET}/streaming"
+SERVER="${BUILD_DIR}/streaming_signaling_server/Release/streaming_signaling_server"
+STREAMER="${BUILD_DIR}/streaming_streamer/Release/streaming_streamer"
+RECEIVER="${BUILD_DIR}/streaming_receiver/Release/streaming_receiver"
+
+for bin in "$SERVER" "$STREAMER" "$RECEIVER"; do
+  if [[ ! -x "$bin" ]]; then
+    echo "Binary not found: $bin"
+    echo "Build first:  cmake --build --preset=${PRESET}"
+    exit 1
+  fi
+done
+
+# --- Log file ---
+LOG_DIR="benchmark_logs"
+mkdir -p "$LOG_DIR"
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "nogit")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/\\' '__')
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="${LOG_DIR}/${TIMESTAMP}_${COMMIT}_${BRANCH}.log"
+
+# Duration: enough frames for all requested reports + startup buffer
+DURATION=$(( REPORTS * REPORT_INTERVAL / FPS + 15 ))
+
+{
+  printf "# streaming benchmark\n"
+  printf "# date:    %s\n" "$(date)"
+  printf "# commit:  %s\n" "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  printf "# branch:  %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+  printf "# preset:  %s\n" "$PRESET"
+  printf "# target:  %d reports x %d frames @ %d fps (~%ds)\n" \
+         "$REPORTS" "$REPORT_INTERVAL" "$FPS" "$DURATION"
+  printf "#\n"
+} > "$LOG_FILE"
+
+echo "Streaming benchmark"
+echo "  reports:  ${REPORTS} x ${REPORT_INTERVAL} frames @ ${FPS} fps"
+echo "  duration: ~${DURATION}s"
+echo "  log:      ${LOG_FILE}"
+echo
+
+# --- Cleanup ---
+SERVER_PID="" STREAMER_PID="" RECEIVER_PID=""
+cleanup() {
+  kill "$SERVER_PID" "$STREAMER_PID" "$RECEIVER_PID" 2>/dev/null || true
+  wait 2>/dev/null || true
+  echo ""
+  echo "Benchmark done. Log: ${LOG_FILE}"
+}
+trap cleanup EXIT INT TERM
+
+# --- Launch (each pipeline: app → prefix → tee to terminal + log) ---
+"${SERVER}"   2>&1 | sed 's/^/[server  ] /' | tee -a "$LOG_FILE" &
+SERVER_PID=$!
+sleep 0.5
+
+"${STREAMER}" 2>&1 | sed 's/^/[streamer] /' | tee -a "$LOG_FILE" &
+STREAMER_PID=$!
+
+"${RECEIVER}" 2>&1 | sed 's/^/[receiver] /' | tee -a "$LOG_FILE" &
+RECEIVER_PID=$!
+
+sleep "$DURATION"

--- a/streaming/CMakeLists.txt
+++ b/streaming/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(SOLUTION_FOLDER streaming)
 
+option(STREAMING_PIPELINE_STATS
+       "Enable per-frame pipeline timing stats (zero overhead when OFF)" ON)
+
 add_subdirectory(streaming_common)
 add_subdirectory(streaming_encode_decode)
 add_subdirectory(streaming_receiver)

--- a/streaming/streaming_common/CMakeLists.txt
+++ b/streaming/streaming_common/CMakeLists.txt
@@ -9,6 +9,10 @@ target_include_directories(
 
 target_link_libraries(streaming_common PUBLIC gp)
 
+target_compile_definitions(
+  streaming_common
+  PUBLIC $<$<BOOL:${STREAMING_PIPELINE_STATS}>:STREAMING_PIPELINE_STATS>)
+
 set_target_properties(streaming_common PROPERTIES FOLDER ${SOLUTION_FOLDER})
 
 source_group(${SOURCE_GROUP_LABEL} FILES ${SRC_FILES})

--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -2,6 +2,7 @@
 
 #include "streaming_common/constants.hpp"
 
+#include <chrono>
 #include <stdexcept>
 
 namespace streaming {
@@ -72,7 +73,12 @@ Decoder::Status Decoder::decode() {
   }
 
   if (packet_sent_) {
+    using Clock = std::chrono::steady_clock;
+
+    const auto t0 = Clock::now();
     auto result = avcodec_receive_frame(context_.get(), frame_.get());
+    const auto t1 = Clock::now();
+    last_timings_.receive_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
 
     if (result == AVERROR(EAGAIN)) {
       packet_sent_ = false;
@@ -90,13 +96,20 @@ Decoder::Status Decoder::decode() {
     }
 
     yuv_to_rgb();
+    const auto t2 = Clock::now();
+    last_timings_.yuv_to_rgb_us = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
     return {Status::Code::OK, static_cast<int>(context_->frame_num)};
   } else {
-    if (upload()) {
+    using Clock = std::chrono::steady_clock;
+
+    const auto t0 = Clock::now();
+    const bool uploaded = upload();
+    const auto t1 = Clock::now();
+    if (uploaded) {
+      last_timings_.upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
       return {Status::Code::RETRY};
-    } else {
-      return {Status::Code::NODATA};
     }
+    return {Status::Code::NODATA};
   }
 }
 

--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -73,12 +73,15 @@ Decoder::Status Decoder::decode() {
   }
 
   if (packet_sent_) {
+#ifdef STREAMING_PIPELINE_STATS
     using Clock = std::chrono::steady_clock;
-
     const auto t0 = Clock::now();
+#endif
     auto result = avcodec_receive_frame(context_.get(), frame_.get());
+#ifdef STREAMING_PIPELINE_STATS
     const auto t1 = Clock::now();
     last_timings_.receive_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
+#endif
 
     if (result == AVERROR(EAGAIN)) {
       packet_sent_ = false;
@@ -96,6 +99,7 @@ Decoder::Status Decoder::decode() {
     }
 
     yuv_to_rgb();
+#ifdef STREAMING_PIPELINE_STATS
     const auto t2 = Clock::now();
     last_timings_.yuv_to_rgb_us = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
     // upload_us is only valid for the first frame decoded from each uploaded packet;
@@ -104,18 +108,26 @@ Decoder::Status Decoder::decode() {
       last_timings_.upload_us = std::chrono::microseconds::zero();
     }
     upload_timing_fresh_ = false;
+#endif
     return {Status::Code::OK, static_cast<int>(context_->frame_num)};
   } else {
+#ifdef STREAMING_PIPELINE_STATS
     using Clock = std::chrono::steady_clock;
-
     const auto t0 = Clock::now();
+#endif
     const bool uploaded = upload();
+#ifdef STREAMING_PIPELINE_STATS
     const auto t1 = Clock::now();
     if (uploaded) {
       last_timings_.upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
       upload_timing_fresh_ = true;
       return {Status::Code::RETRY};
     }
+#else
+    if (uploaded) {
+      return {Status::Code::RETRY};
+    }
+#endif
     return {Status::Code::NODATA};
   }
 }

--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -98,6 +98,12 @@ Decoder::Status Decoder::decode() {
     yuv_to_rgb();
     const auto t2 = Clock::now();
     last_timings_.yuv_to_rgb_us = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
+    // upload_us is only valid for the first frame decoded from each uploaded packet;
+    // clear it so subsequent frames from the same packet don't inherit a stale value.
+    if (!upload_timing_fresh_) {
+      last_timings_.upload_us = std::chrono::microseconds::zero();
+    }
+    upload_timing_fresh_ = false;
     return {Status::Code::OK, static_cast<int>(context_->frame_num)};
   } else {
     using Clock = std::chrono::steady_clock;
@@ -107,6 +113,7 @@ Decoder::Status Decoder::decode() {
     const auto t1 = Clock::now();
     if (uploaded) {
       last_timings_.upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
+      upload_timing_fresh_ = true;
       return {Status::Code::RETRY};
     }
     return {Status::Code::NODATA};

--- a/streaming/streaming_common/decoder.hpp
+++ b/streaming/streaming_common/decoder.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -39,6 +40,12 @@ public:
     int frame_num;
   };
 
+  struct Timings {
+    std::chrono::microseconds upload_us{};
+    std::chrono::microseconds receive_us{};
+    std::chrono::microseconds yuv_to_rgb_us{};
+  };
+
   Decoder() = default;
 
   ~Decoder();
@@ -51,6 +58,9 @@ public:
   void init(const VideoStreamInfo &video_stream_info);
 
   std::shared_ptr<FrameData> rgb_frame();
+
+  const Timings &last_timings() const noexcept { return last_timings_; }
+
   /**
    * Prepares another frame available through @ref rgb_frame().
    */
@@ -86,6 +96,8 @@ private:
 
   std::vector<std::uint8_t> async_buffer_{};
   std::mutex async_buffer_mutex_{};
+
+  Timings last_timings_{};
 
   /**
    * Packet was sent by avcodec_send_packet - expected to receive frames first.

--- a/streaming/streaming_common/decoder.hpp
+++ b/streaming/streaming_common/decoder.hpp
@@ -104,6 +104,10 @@ private:
    */
   bool packet_sent_{false};
   /**
+   * True immediately after upload(); cleared after the first OK frame reads upload_us.
+   */
+  bool upload_timing_fresh_{false};
+  /**
    * EOF signaled from the outside - no more data accepted.
    */
   std::atomic_bool signaled_eof_{};

--- a/streaming/streaming_common/decoder.hpp
+++ b/streaming/streaming_common/decoder.hpp
@@ -7,7 +7,9 @@
 
 #include <array>
 #include <atomic>
-#include <chrono>
+#ifdef STREAMING_PIPELINE_STATS
+# include <chrono>
+#endif
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -40,11 +42,13 @@ public:
     int frame_num;
   };
 
+#ifdef STREAMING_PIPELINE_STATS
   struct Timings {
     std::chrono::microseconds upload_us{};
     std::chrono::microseconds receive_us{};
     std::chrono::microseconds yuv_to_rgb_us{};
   };
+#endif
 
   Decoder() = default;
 
@@ -59,7 +63,9 @@ public:
 
   std::shared_ptr<FrameData> rgb_frame();
 
+#ifdef STREAMING_PIPELINE_STATS
   const Timings &last_timings() const noexcept { return last_timings_; }
+#endif
 
   /**
    * Prepares another frame available through @ref rgb_frame().
@@ -97,7 +103,9 @@ private:
   std::vector<std::uint8_t> async_buffer_{};
   std::mutex async_buffer_mutex_{};
 
+#ifdef STREAMING_PIPELINE_STATS
   Timings last_timings_{};
+#endif
 
   /**
    * Packet was sent by avcodec_send_packet - expected to receive frames first.
@@ -106,7 +114,9 @@ private:
   /**
    * True immediately after upload(); cleared after the first OK frame reads upload_us.
    */
+#ifdef STREAMING_PIPELINE_STATS
   bool upload_timing_fresh_{false};
+#endif
   /**
    * EOF signaled from the outside - no more data accepted.
    */

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -100,19 +100,26 @@ void Encoder::encode() {
     throw std::runtime_error{"av_frame_make_writable failed"};
   }
 
+#ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
-
   const auto t0 = Clock::now();
+#endif
   flip_frame();
+#ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();
+#endif
   rgb_to_yuv();
+#ifdef STREAMING_PIPELINE_STATS
   const auto t2 = Clock::now();
+#endif
   encode_frame(frame_.get());
+#ifdef STREAMING_PIPELINE_STATS
   const auto t3 = Clock::now();
 
   last_timings_.flip_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
   last_timings_.rgb_to_yuv_us = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
   last_timings_.encode_us = std::chrono::duration_cast<std::chrono::microseconds>(t3 - t2);
+#endif
 
   frame_->pts++;
 }

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -3,6 +3,7 @@
 #include "streaming_common/constants.hpp"
 
 #include <array>
+#include <chrono>
 #include <stdexcept>
 #include <string>
 
@@ -99,10 +100,19 @@ void Encoder::encode() {
     throw std::runtime_error{"av_frame_make_writable failed"};
   }
 
-  flip_frame();
-  rgb_to_yuv();
+  using Clock = std::chrono::steady_clock;
 
+  const auto t0 = Clock::now();
+  flip_frame();
+  const auto t1 = Clock::now();
+  rgb_to_yuv();
+  const auto t2 = Clock::now();
   encode_frame(frame_.get());
+  const auto t3 = Clock::now();
+
+  last_timings_.flip_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
+  last_timings_.rgb_to_yuv_us = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
+  last_timings_.encode_us = std::chrono::duration_cast<std::chrono::microseconds>(t3 - t2);
 
   frame_->pts++;
 }

--- a/streaming/streaming_common/encoder.hpp
+++ b/streaming/streaming_common/encoder.hpp
@@ -5,12 +5,19 @@
 
 #include <gp/ffmpeg/ffmpeg.hpp>
 
+#include <chrono>
 #include <functional>
 #include <memory>
 
 namespace streaming {
 class Encoder {
 public:
+  struct Timings {
+    std::chrono::microseconds flip_us{};
+    std::chrono::microseconds rgb_to_yuv_us{};
+    std::chrono::microseconds encode_us{};
+  };
+
   explicit Encoder(const VideoStreamInfo &video_stream_info);
   Encoder(const Encoder &) = delete;
   Encoder &operator=(const Encoder &) = delete;
@@ -21,6 +28,9 @@ public:
 
   std::shared_ptr<FrameData> video_frame();
   VideoStreamInfo video_stream_info() const;
+
+  const Timings &last_timings() const noexcept { return last_timings_; }
+
   void set_video_stream_callback(
       std::function<void(const std::byte *data, const std::size_t size, const bool eof)> video_stream_callback);
   void encode();
@@ -34,6 +44,8 @@ private:
 
   std::shared_ptr<FrameData> video_frame_{};
   FrameData rgb_frame_{};
+
+  Timings last_timings_{};
 
   const AVCodec *codec_{};
   gp::ffmpeg::UniqueAVCodecContext context_{};

--- a/streaming/streaming_common/encoder.hpp
+++ b/streaming/streaming_common/encoder.hpp
@@ -5,18 +5,22 @@
 
 #include <gp/ffmpeg/ffmpeg.hpp>
 
-#include <chrono>
+#ifdef STREAMING_PIPELINE_STATS
+# include <chrono>
+#endif
 #include <functional>
 #include <memory>
 
 namespace streaming {
 class Encoder {
 public:
+#ifdef STREAMING_PIPELINE_STATS
   struct Timings {
     std::chrono::microseconds flip_us{};
     std::chrono::microseconds rgb_to_yuv_us{};
     std::chrono::microseconds encode_us{};
   };
+#endif
 
   explicit Encoder(const VideoStreamInfo &video_stream_info);
   Encoder(const Encoder &) = delete;
@@ -29,7 +33,9 @@ public:
   std::shared_ptr<FrameData> video_frame();
   VideoStreamInfo video_stream_info() const;
 
+#ifdef STREAMING_PIPELINE_STATS
   const Timings &last_timings() const noexcept { return last_timings_; }
+#endif
 
   void set_video_stream_callback(
       std::function<void(const std::byte *data, const std::size_t size, const bool eof)> video_stream_callback);
@@ -45,7 +51,9 @@ private:
   std::shared_ptr<FrameData> video_frame_{};
   FrameData rgb_frame_{};
 
+#ifdef STREAMING_PIPELINE_STATS
   Timings last_timings_{};
+#endif
 
   const AVCodec *codec_{};
   gp::ffmpeg::UniqueAVCodecContext context_{};

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <limits>
@@ -8,7 +9,7 @@
 namespace streaming {
 
 struct StageStats {
-  std::chrono::microseconds min{std::numeric_limits<int64_t>::max()};
+  std::chrono::microseconds min{std::numeric_limits<std::chrono::microseconds::rep>::max()};
   std::chrono::microseconds max{std::chrono::microseconds::zero()};
   std::chrono::microseconds sum{std::chrono::microseconds::zero()};
   uint32_t count{0};
@@ -27,7 +28,7 @@ struct StageStats {
   std::chrono::microseconds avg() const noexcept { return count > 0 ? sum / count : std::chrono::microseconds::zero(); }
 
   void reset() noexcept {
-    min = std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
+    min = std::chrono::microseconds{std::numeric_limits<std::chrono::microseconds::rep>::max()};
     max = std::chrono::microseconds::zero();
     sum = std::chrono::microseconds::zero();
     count = 0;
@@ -69,16 +70,16 @@ private:
     print_stage("  rgb->yuv    ", rgb_to_yuv_);
     print_stage("  encode      ", encode_);
     const auto total = render_.avg() + capture_.avg() + flip_.avg() + rgb_to_yuv_.avg() + encode_.avg();
-    printf("  total (avg) : %6lld us\n", static_cast<long long>(total.count()));
+    printf("  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
     printf("----------------------------------------------\n");
   }
 
   static void print_stage(const char *name, const StageStats &s) {
-    printf("%s min=%6lld  avg=%6lld  max=%6lld us\n",
+    printf("%s min=%6" PRId64 "  avg=%6" PRId64 "  max=%6" PRId64 " us\n",
            name,
-           static_cast<long long>(s.count > 0 ? s.min.count() : 0),
-           static_cast<long long>(s.avg().count()),
-           static_cast<long long>(s.max.count()));
+           static_cast<int64_t>(s.count > 0 ? s.min.count() : 0),
+           static_cast<int64_t>(s.avg().count()),
+           static_cast<int64_t>(s.max.count()));
   }
 
   void reset() noexcept {
@@ -131,16 +132,16 @@ private:
     print_stage("  tex upload  ", texture_upload_);
     print_stage("  display     ", display_);
     const auto total = upload_.avg() + receive_.avg() + yuv_to_rgb_.avg() + texture_upload_.avg() + display_.avg();
-    printf("  total (avg) : %6lld us\n", static_cast<long long>(total.count()));
+    printf("  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
     printf("----------------------------------------------\n");
   }
 
   static void print_stage(const char *name, const StageStats &s) {
-    printf("%s min=%6lld  avg=%6lld  max=%6lld us\n",
+    printf("%s min=%6" PRId64 "  avg=%6" PRId64 "  max=%6" PRId64 " us\n",
            name,
-           static_cast<long long>(s.count > 0 ? s.min.count() : 0),
-           static_cast<long long>(s.avg().count()),
-           static_cast<long long>(s.max.count()));
+           static_cast<int64_t>(s.count > 0 ? s.min.count() : 0),
+           static_cast<int64_t>(s.avg().count()),
+           static_cast<int64_t>(s.max.count()));
   }
 
   void reset() noexcept {

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -6,9 +6,7 @@
 # include <cinttypes>
 # include <cstdint>
 # include <cstdio>
-# include <cstring>
 # include <limits>
-# include <string>
 
 namespace streaming {
 
@@ -51,16 +49,7 @@ public:
     std::chrono::microseconds encode_us{};
   };
 
-  ~EncodeStats() noexcept {
-    if (owned_file_ != nullptr) {
-      std::fclose(owned_file_);
-    }
-  }
-
-  void set_output_dir(std::string base_dir, std::string filename) noexcept {
-    log_base_dir_ = std::move(base_dir);
-    log_filename_ = std::move(filename);
-  }
+  void set_output(std::FILE *out) noexcept { out_ = out; }
 
   void record(const Frame &f) noexcept {
     render_.record(f.render_us);
@@ -71,38 +60,12 @@ public:
     ++frame_count_;
 
     if (frame_count_ >= PIPELINE_STATS_REPORT_INTERVAL) {
-      try_open_output();
       report();
       reset();
     }
   }
 
 private:
-  void try_open_output() noexcept {
-    if (out_ != stdout || log_base_dir_.empty() || owned_file_ != nullptr) {
-      return;
-    }
-    const auto current_path = log_base_dir_ + "/.current";
-    auto *f = std::fopen(current_path.c_str(), "r");
-    if (f == nullptr) {
-      return;
-    }
-    char session[4096]{};
-    if (std::fgets(session, sizeof(session), f) != nullptr) {
-      const auto len = std::strlen(session);
-      auto end = len;
-      while (end > 0 && (session[end - 1] == '\n' || session[end - 1] == '\r')) {
-        session[--end] = '\0';
-      }
-      const auto log_path = std::string(session) + "/" + log_filename_;
-      owned_file_ = std::fopen(log_path.c_str(), "a");
-      if (owned_file_ != nullptr) {
-        out_ = owned_file_;
-      }
-    }
-    std::fclose(f);
-  }
-
   void report() const {
     fprintf(out_, "\n--- Encode pipeline stats (over %u frames) ---\n", frame_count_);
     print_stage(out_, "  render      ", render_);
@@ -134,9 +97,6 @@ private:
     frame_count_ = 0;
   }
 
-  std::string log_base_dir_{};
-  std::string log_filename_{};
-  std::FILE *owned_file_{nullptr};
   StageStats render_{};
   StageStats capture_{};
   StageStats flip_{};

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -118,7 +118,9 @@ public:
 
   void set_output(std::FILE *out) noexcept { out_ = out; }
 
-  void record(const Frame &f) noexcept {
+  void set_max_reports(uint32_t n) noexcept { max_reports_ = n; }
+
+  bool record(const Frame &f) noexcept {
     upload_.record(f.upload_us);
     receive_.record(f.receive_us);
     yuv_to_rgb_.record(f.yuv_to_rgb_us);
@@ -129,7 +131,10 @@ public:
     if (frame_count_ >= PIPELINE_STATS_REPORT_INTERVAL) {
       report();
       reset();
+      ++reports_count_;
+      return max_reports_ > 0u && reports_count_ >= max_reports_;
     }
+    return false;
   }
 
 private:
@@ -170,6 +175,8 @@ private:
   StageStats texture_upload_{};
   StageStats display_{};
   uint32_t frame_count_{0};
+  uint32_t reports_count_{0};
+  uint32_t max_reports_{0};
   std::FILE *out_{stdout};
 };
 

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <chrono>
-#include <cinttypes>
-#include <cstdint>
-#include <cstdio>
-#include <limits>
+#ifdef STREAMING_PIPELINE_STATS
+
+# include <chrono>
+# include <cinttypes>
+# include <cstdint>
+# include <cstdio>
+# include <limits>
 
 namespace streaming {
 
@@ -162,3 +164,5 @@ private:
 };
 
 } // namespace streaming
+
+#endif // STREAMING_PIPELINE_STATS

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -49,6 +49,8 @@ public:
     std::chrono::microseconds encode_us{};
   };
 
+  void set_output(std::FILE *out) noexcept { out_ = out; }
+
   void record(const Frame &f) noexcept {
     render_.record(f.render_us);
     capture_.record(f.capture_us);
@@ -65,23 +67,25 @@ public:
 
 private:
   void report() const {
-    printf("\n--- Encode pipeline stats (over %u frames) ---\n", frame_count_);
-    print_stage("  render      ", render_);
-    print_stage("  capture     ", capture_);
-    print_stage("  flip        ", flip_);
-    print_stage("  rgb->yuv    ", rgb_to_yuv_);
-    print_stage("  encode      ", encode_);
+    fprintf(out_, "\n--- Encode pipeline stats (over %u frames) ---\n", frame_count_);
+    print_stage(out_, "  render      ", render_);
+    print_stage(out_, "  capture     ", capture_);
+    print_stage(out_, "  flip        ", flip_);
+    print_stage(out_, "  rgb->yuv    ", rgb_to_yuv_);
+    print_stage(out_, "  encode      ", encode_);
     const auto total = render_.avg() + capture_.avg() + flip_.avg() + rgb_to_yuv_.avg() + encode_.avg();
-    printf("  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
-    printf("----------------------------------------------\n");
+    fprintf(out_, "  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
+    fprintf(out_, "----------------------------------------------\n");
+    std::fflush(out_);
   }
 
-  static void print_stage(const char *name, const StageStats &s) {
-    printf("%s min=%6" PRId64 "  avg=%6" PRId64 "  max=%6" PRId64 " us\n",
-           name,
-           static_cast<int64_t>(s.count > 0 ? s.min.count() : 0),
-           static_cast<int64_t>(s.avg().count()),
-           static_cast<int64_t>(s.max.count()));
+  static void print_stage(std::FILE *out, const char *name, const StageStats &s) {
+    fprintf(out,
+            "%s min=%6" PRId64 "  avg=%6" PRId64 "  max=%6" PRId64 " us\n",
+            name,
+            static_cast<int64_t>(s.count > 0 ? s.min.count() : 0),
+            static_cast<int64_t>(s.avg().count()),
+            static_cast<int64_t>(s.max.count()));
   }
 
   void reset() noexcept {
@@ -99,6 +103,7 @@ private:
   StageStats rgb_to_yuv_{};
   StageStats encode_{};
   uint32_t frame_count_{0};
+  std::FILE *out_{stdout};
 };
 
 class DecodeStats {
@@ -110,6 +115,8 @@ public:
     std::chrono::microseconds texture_upload_us{};
     std::chrono::microseconds display_us{};
   };
+
+  void set_output(std::FILE *out) noexcept { out_ = out; }
 
   void record(const Frame &f) noexcept {
     upload_.record(f.upload_us);
@@ -127,23 +134,25 @@ public:
 
 private:
   void report() const {
-    printf("\n--- Decode pipeline stats (over %u frames) ---\n", frame_count_);
-    print_stage("  upload      ", upload_);
-    print_stage("  receive     ", receive_);
-    print_stage("  yuv->rgb    ", yuv_to_rgb_);
-    print_stage("  tex upload  ", texture_upload_);
-    print_stage("  display     ", display_);
+    fprintf(out_, "\n--- Decode pipeline stats (over %u frames) ---\n", frame_count_);
+    print_stage(out_, "  upload      ", upload_);
+    print_stage(out_, "  receive     ", receive_);
+    print_stage(out_, "  yuv->rgb    ", yuv_to_rgb_);
+    print_stage(out_, "  tex upload  ", texture_upload_);
+    print_stage(out_, "  display     ", display_);
     const auto total = upload_.avg() + receive_.avg() + yuv_to_rgb_.avg() + texture_upload_.avg() + display_.avg();
-    printf("  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
-    printf("----------------------------------------------\n");
+    fprintf(out_, "  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
+    fprintf(out_, "----------------------------------------------\n");
+    std::fflush(out_);
   }
 
-  static void print_stage(const char *name, const StageStats &s) {
-    printf("%s min=%6" PRId64 "  avg=%6" PRId64 "  max=%6" PRId64 " us\n",
-           name,
-           static_cast<int64_t>(s.count > 0 ? s.min.count() : 0),
-           static_cast<int64_t>(s.avg().count()),
-           static_cast<int64_t>(s.max.count()));
+  static void print_stage(std::FILE *out, const char *name, const StageStats &s) {
+    fprintf(out,
+            "%s min=%6" PRId64 "  avg=%6" PRId64 "  max=%6" PRId64 " us\n",
+            name,
+            static_cast<int64_t>(s.count > 0 ? s.min.count() : 0),
+            static_cast<int64_t>(s.avg().count()),
+            static_cast<int64_t>(s.max.count()));
   }
 
   void reset() noexcept {
@@ -161,6 +170,7 @@ private:
   StageStats texture_upload_{};
   StageStats display_{};
   uint32_t frame_count_{0};
+  std::FILE *out_{stdout};
 };
 
 } // namespace streaming

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+namespace streaming {
+
+struct StageStats {
+  std::chrono::microseconds min{std::numeric_limits<int64_t>::max()};
+  std::chrono::microseconds max{std::chrono::microseconds::zero()};
+  std::chrono::microseconds sum{std::chrono::microseconds::zero()};
+  uint32_t count{0};
+
+  void record(std::chrono::microseconds d) noexcept {
+    if (d < min) {
+      min = d;
+    }
+    if (d > max) {
+      max = d;
+    }
+    sum += d;
+    ++count;
+  }
+
+  std::chrono::microseconds avg() const noexcept { return count > 0 ? sum / count : std::chrono::microseconds::zero(); }
+
+  void reset() noexcept {
+    min = std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
+    max = std::chrono::microseconds::zero();
+    sum = std::chrono::microseconds::zero();
+    count = 0;
+  }
+};
+
+constexpr uint32_t PIPELINE_STATS_REPORT_INTERVAL = 100u;
+
+class EncodeStats {
+public:
+  struct Frame {
+    std::chrono::microseconds render_us{};
+    std::chrono::microseconds capture_us{};
+    std::chrono::microseconds flip_us{};
+    std::chrono::microseconds rgb_to_yuv_us{};
+    std::chrono::microseconds encode_us{};
+  };
+
+  void record(const Frame &f) noexcept {
+    render_.record(f.render_us);
+    capture_.record(f.capture_us);
+    flip_.record(f.flip_us);
+    rgb_to_yuv_.record(f.rgb_to_yuv_us);
+    encode_.record(f.encode_us);
+    ++frame_count_;
+
+    if (frame_count_ >= PIPELINE_STATS_REPORT_INTERVAL) {
+      report();
+      reset();
+    }
+  }
+
+private:
+  void report() const {
+    printf("\n--- Encode pipeline stats (over %u frames) ---\n", frame_count_);
+    print_stage("  render      ", render_);
+    print_stage("  capture     ", capture_);
+    print_stage("  flip        ", flip_);
+    print_stage("  rgb->yuv    ", rgb_to_yuv_);
+    print_stage("  encode      ", encode_);
+    const auto total = render_.avg() + capture_.avg() + flip_.avg() + rgb_to_yuv_.avg() + encode_.avg();
+    printf("  total (avg) : %6lld us\n", static_cast<long long>(total.count()));
+    printf("----------------------------------------------\n");
+  }
+
+  static void print_stage(const char *name, const StageStats &s) {
+    printf("%s min=%6lld  avg=%6lld  max=%6lld us\n",
+           name,
+           static_cast<long long>(s.count > 0 ? s.min.count() : 0),
+           static_cast<long long>(s.avg().count()),
+           static_cast<long long>(s.max.count()));
+  }
+
+  void reset() noexcept {
+    render_.reset();
+    capture_.reset();
+    flip_.reset();
+    rgb_to_yuv_.reset();
+    encode_.reset();
+    frame_count_ = 0;
+  }
+
+  StageStats render_{};
+  StageStats capture_{};
+  StageStats flip_{};
+  StageStats rgb_to_yuv_{};
+  StageStats encode_{};
+  uint32_t frame_count_{0};
+};
+
+class DecodeStats {
+public:
+  struct Frame {
+    std::chrono::microseconds upload_us{};
+    std::chrono::microseconds receive_us{};
+    std::chrono::microseconds yuv_to_rgb_us{};
+    std::chrono::microseconds texture_upload_us{};
+    std::chrono::microseconds display_us{};
+  };
+
+  void record(const Frame &f) noexcept {
+    upload_.record(f.upload_us);
+    receive_.record(f.receive_us);
+    yuv_to_rgb_.record(f.yuv_to_rgb_us);
+    texture_upload_.record(f.texture_upload_us);
+    display_.record(f.display_us);
+    ++frame_count_;
+
+    if (frame_count_ >= PIPELINE_STATS_REPORT_INTERVAL) {
+      report();
+      reset();
+    }
+  }
+
+private:
+  void report() const {
+    printf("\n--- Decode pipeline stats (over %u frames) ---\n", frame_count_);
+    print_stage("  upload      ", upload_);
+    print_stage("  receive     ", receive_);
+    print_stage("  yuv->rgb    ", yuv_to_rgb_);
+    print_stage("  tex upload  ", texture_upload_);
+    print_stage("  display     ", display_);
+    const auto total = upload_.avg() + receive_.avg() + yuv_to_rgb_.avg() + texture_upload_.avg() + display_.avg();
+    printf("  total (avg) : %6lld us\n", static_cast<long long>(total.count()));
+    printf("----------------------------------------------\n");
+  }
+
+  static void print_stage(const char *name, const StageStats &s) {
+    printf("%s min=%6lld  avg=%6lld  max=%6lld us\n",
+           name,
+           static_cast<long long>(s.count > 0 ? s.min.count() : 0),
+           static_cast<long long>(s.avg().count()),
+           static_cast<long long>(s.max.count()));
+  }
+
+  void reset() noexcept {
+    upload_.reset();
+    receive_.reset();
+    yuv_to_rgb_.reset();
+    texture_upload_.reset();
+    display_.reset();
+    frame_count_ = 0;
+  }
+
+  StageStats upload_{};
+  StageStats receive_{};
+  StageStats yuv_to_rgb_{};
+  StageStats texture_upload_{};
+  StageStats display_{};
+  uint32_t frame_count_{0};
+};
+
+} // namespace streaming

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -67,7 +67,7 @@ public:
 
 private:
   void report() const {
-    fprintf(out_, "\n--- Encode pipeline stats (over %u frames) ---\n", frame_count_);
+    fprintf(out_, "--- Encode pipeline stats (over %u frames) ---\n", frame_count_);
     print_stage(out_, "  render      ", render_);
     print_stage(out_, "  capture     ", capture_);
     print_stage(out_, "  flip        ", flip_);
@@ -75,7 +75,7 @@ private:
     print_stage(out_, "  encode      ", encode_);
     const auto total = render_.avg() + capture_.avg() + flip_.avg() + rgb_to_yuv_.avg() + encode_.avg();
     fprintf(out_, "  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
-    fprintf(out_, "----------------------------------------------\n");
+    fprintf(out_, "----------------------------------------------\n\n");
     std::fflush(out_);
   }
 
@@ -139,7 +139,7 @@ public:
 
 private:
   void report() const {
-    fprintf(out_, "\n--- Decode pipeline stats (over %u frames) ---\n", frame_count_);
+    fprintf(out_, "--- Decode pipeline stats (over %u frames) ---\n", frame_count_);
     print_stage(out_, "  upload      ", upload_);
     print_stage(out_, "  receive     ", receive_);
     print_stage(out_, "  yuv->rgb    ", yuv_to_rgb_);
@@ -147,7 +147,7 @@ private:
     print_stage(out_, "  display     ", display_);
     const auto total = upload_.avg() + receive_.avg() + yuv_to_rgb_.avg() + texture_upload_.avg() + display_.avg();
     fprintf(out_, "  total (avg) : %6" PRId64 " us\n", static_cast<int64_t>(total.count()));
-    fprintf(out_, "----------------------------------------------\n");
+    fprintf(out_, "----------------------------------------------\n\n");
     std::fflush(out_);
   }
 

--- a/streaming/streaming_common/pipeline_stats.hpp
+++ b/streaming/streaming_common/pipeline_stats.hpp
@@ -6,7 +6,9 @@
 # include <cinttypes>
 # include <cstdint>
 # include <cstdio>
+# include <cstring>
 # include <limits>
+# include <string>
 
 namespace streaming {
 
@@ -49,7 +51,16 @@ public:
     std::chrono::microseconds encode_us{};
   };
 
-  void set_output(std::FILE *out) noexcept { out_ = out; }
+  ~EncodeStats() noexcept {
+    if (owned_file_ != nullptr) {
+      std::fclose(owned_file_);
+    }
+  }
+
+  void set_output_dir(std::string base_dir, std::string filename) noexcept {
+    log_base_dir_ = std::move(base_dir);
+    log_filename_ = std::move(filename);
+  }
 
   void record(const Frame &f) noexcept {
     render_.record(f.render_us);
@@ -60,12 +71,38 @@ public:
     ++frame_count_;
 
     if (frame_count_ >= PIPELINE_STATS_REPORT_INTERVAL) {
+      try_open_output();
       report();
       reset();
     }
   }
 
 private:
+  void try_open_output() noexcept {
+    if (out_ != stdout || log_base_dir_.empty() || owned_file_ != nullptr) {
+      return;
+    }
+    const auto current_path = log_base_dir_ + "/.current";
+    auto *f = std::fopen(current_path.c_str(), "r");
+    if (f == nullptr) {
+      return;
+    }
+    char session[4096]{};
+    if (std::fgets(session, sizeof(session), f) != nullptr) {
+      const auto len = std::strlen(session);
+      auto end = len;
+      while (end > 0 && (session[end - 1] == '\n' || session[end - 1] == '\r')) {
+        session[--end] = '\0';
+      }
+      const auto log_path = std::string(session) + "/" + log_filename_;
+      owned_file_ = std::fopen(log_path.c_str(), "a");
+      if (owned_file_ != nullptr) {
+        out_ = owned_file_;
+      }
+    }
+    std::fclose(f);
+  }
+
   void report() const {
     fprintf(out_, "\n--- Encode pipeline stats (over %u frames) ---\n", frame_count_);
     print_stage(out_, "  render      ", render_);
@@ -97,6 +134,9 @@ private:
     frame_count_ = 0;
   }
 
+  std::string log_base_dir_{};
+  std::string log_filename_{};
+  std::FILE *owned_file_{nullptr};
   StageStats render_{};
   StageStats capture_{};
   StageStats flip_{};

--- a/streaming/streaming_encode_decode/decode_scene.cpp
+++ b/streaming/streaming_encode_decode/decode_scene.cpp
@@ -74,8 +74,10 @@ void DecodeScene::decode() {
   const auto status = decoder_->decode();
   switch (status.code) {
   case Decoder::Status::Code::OK: {
+#ifdef STREAMING_PIPELINE_STATS
     using Clock = std::chrono::steady_clock;
     const auto t0 = Clock::now();
+#endif
     frame_texture_->bind();
     frame_texture_->set_image(0,
                               format,
@@ -85,12 +87,14 @@ void DecodeScene::decode() {
                               format,
                               GL_UNSIGNED_BYTE,
                               rgb_frame_->data());
+#ifdef STREAMING_PIPELINE_STATS
     const auto t1 = Clock::now();
     const auto &dec_t = decoder_->last_timings();
     pending_decode_frame_ = {.upload_us = dec_t.upload_us,
                              .receive_us = dec_t.receive_us,
                              .yuv_to_rgb_us = dec_t.yuv_to_rgb_us,
                              .texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)};
+#endif
     frame_ready_ = true;
     break;
   }
@@ -116,8 +120,10 @@ bool DecodeScene::redraw() {
     return false;
   }
 
+#ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
   const auto t0 = Clock::now();
+#endif
 
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glActiveTexture(GL_TEXTURE0);
@@ -126,8 +132,10 @@ bool DecodeScene::redraw() {
   vao_->bind();
   glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
+#ifdef STREAMING_PIPELINE_STATS
   pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
   decode_stats_.record(pending_decode_frame_);
+#endif
 
   frame_ready_ = false;
   return true;

--- a/streaming/streaming_encode_decode/decode_scene.cpp
+++ b/streaming/streaming_encode_decode/decode_scene.cpp
@@ -7,6 +7,7 @@
 #include <gp/misc/event.hpp>
 
 #include <array>
+#include <chrono>
 
 namespace streaming {
 namespace {
@@ -72,8 +73,9 @@ void DecodeScene::decode() {
 
   const auto status = decoder_->decode();
   switch (status.code) {
-  case Decoder::Status::Code::OK:
-    printf("Decoding: decoded frame: %i\n", status.frame_num);
+  case Decoder::Status::Code::OK: {
+    using Clock = std::chrono::steady_clock;
+    const auto t0 = Clock::now();
     frame_texture_->bind();
     frame_texture_->set_image(0,
                               format,
@@ -83,10 +85,16 @@ void DecodeScene::decode() {
                               format,
                               GL_UNSIGNED_BYTE,
                               rgb_frame_->data());
+    const auto t1 = Clock::now();
+    const auto &dec_t = decoder_->last_timings();
+    pending_decode_frame_ = {.upload_us = dec_t.upload_us,
+                             .receive_us = dec_t.receive_us,
+                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us,
+                             .texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)};
     frame_ready_ = true;
     break;
+  }
   case Decoder::Status::Code::RETRY:
-    printf("Decoding: packet sent, retrying...\n");
     break;
   case Decoder::Status::Code::EOS:
     printf("Decoding: end of stream\n");
@@ -108,12 +116,19 @@ bool DecodeScene::redraw() {
     return false;
   }
 
+  using Clock = std::chrono::steady_clock;
+  const auto t0 = Clock::now();
+
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glActiveTexture(GL_TEXTURE0);
   shader_program_->use();
   frame_texture_->bind();
   vao_->bind();
   glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+  pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+  decode_stats_.record(pending_decode_frame_);
+
   frame_ready_ = false;
   return true;
 }

--- a/streaming/streaming_encode_decode/decode_scene.hpp
+++ b/streaming/streaming_encode_decode/decode_scene.hpp
@@ -2,6 +2,7 @@
 
 #include "streaming_common/decoder.hpp"
 #include "streaming_common/frame_data.hpp"
+#include "streaming_common/pipeline_stats.hpp"
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -48,5 +49,8 @@ private:
   std::unique_ptr<gp::gl::BufferObject> vertex_buffer_{};
   std::unique_ptr<gp::gl::TextureObject> frame_texture_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
+
+  DecodeStats::Frame pending_decode_frame_{};
+  DecodeStats decode_stats_{};
 };
 } // namespace streaming

--- a/streaming/streaming_encode_decode/decode_scene.hpp
+++ b/streaming/streaming_encode_decode/decode_scene.hpp
@@ -2,7 +2,9 @@
 
 #include "streaming_common/decoder.hpp"
 #include "streaming_common/frame_data.hpp"
-#include "streaming_common/pipeline_stats.hpp"
+#ifdef STREAMING_PIPELINE_STATS
+# include "streaming_common/pipeline_stats.hpp"
+#endif
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -50,7 +52,9 @@ private:
   std::unique_ptr<gp::gl::TextureObject> frame_texture_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
 
+#ifdef STREAMING_PIPELINE_STATS
   DecodeStats::Frame pending_decode_frame_{};
   DecodeStats decode_stats_{};
+#endif
 };
 } // namespace streaming

--- a/streaming/streaming_encode_decode/encode_scene.cpp
+++ b/streaming/streaming_encode_decode/encode_scene.cpp
@@ -10,6 +10,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include <array>
+#include <chrono>
 
 namespace streaming {
 namespace {
@@ -72,6 +73,9 @@ void EncodeScene::animate(const std::uint64_t time_elapsed_ms) {
 }
 
 void EncodeScene::redraw() {
+  using Clock = std::chrono::steady_clock;
+  const auto t0 = Clock::now();
+
   auto camera_rot_mat = glm::rotate(glm::mat4(1.0f), glm::radians(camera_rot_.x), glm::vec3(1.0f, 0.0f, 0.0f));
   camera_rot_mat = glm::rotate(camera_rot_mat, glm::radians(camera_rot_.y), glm::vec3(0.0f, 1.0f, 0.0f));
   camera_rot_mat = glm::rotate(camera_rot_mat, glm::radians(camera_rot_.z), glm::vec3(0.0f, 0.0f, 1.0f));
@@ -86,10 +90,16 @@ void EncodeScene::redraw() {
 
   vao_->bind();
   glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, nullptr);
+
+  last_render_us_ = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
 }
 
 void EncodeScene::encode() {
   constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
+
+  using Clock = std::chrono::steady_clock;
+
+  const auto t0 = Clock::now();
   glReadPixels(0,
                0,
                video_stream_info_.width,
@@ -97,7 +107,15 @@ void EncodeScene::encode() {
                format,
                GL_UNSIGNED_BYTE,
                video_frame_->data());
+  const auto t1 = Clock::now();
   encoder_->encode();
+
+  const auto &enc_t = encoder_->last_timings();
+  encode_stats_.record({.render_us = last_render_us_,
+                        .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
+                        .flip_us = enc_t.flip_us,
+                        .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
+                        .encode_us = enc_t.encode_us});
 }
 
 void EncodeScene::init_streaming() {

--- a/streaming/streaming_encode_decode/encode_scene.cpp
+++ b/streaming/streaming_encode_decode/encode_scene.cpp
@@ -73,8 +73,10 @@ void EncodeScene::animate(const std::uint64_t time_elapsed_ms) {
 }
 
 void EncodeScene::redraw() {
+#ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
   const auto t0 = Clock::now();
+#endif
 
   auto camera_rot_mat = glm::rotate(glm::mat4(1.0f), glm::radians(camera_rot_.x), glm::vec3(1.0f, 0.0f, 0.0f));
   camera_rot_mat = glm::rotate(camera_rot_mat, glm::radians(camera_rot_.y), glm::vec3(0.0f, 1.0f, 0.0f));
@@ -91,15 +93,19 @@ void EncodeScene::redraw() {
   vao_->bind();
   glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, nullptr);
 
+#ifdef STREAMING_PIPELINE_STATS
   last_render_us_ = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+#endif
 }
 
 void EncodeScene::encode() {
   constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
 
+#ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
 
   const auto t0 = Clock::now();
+#endif
   glReadPixels(0,
                0,
                video_stream_info_.width,
@@ -107,15 +113,19 @@ void EncodeScene::encode() {
                format,
                GL_UNSIGNED_BYTE,
                video_frame_->data());
+#ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();
+#endif
   encoder_->encode();
 
+#ifdef STREAMING_PIPELINE_STATS
   const auto &enc_t = encoder_->last_timings();
   encode_stats_.record({.render_us = last_render_us_,
                         .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
                         .flip_us = enc_t.flip_us,
                         .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
                         .encode_us = enc_t.encode_us});
+#endif
 }
 
 void EncodeScene::init_streaming() {

--- a/streaming/streaming_encode_decode/encode_scene.hpp
+++ b/streaming/streaming_encode_decode/encode_scene.hpp
@@ -2,7 +2,9 @@
 
 #include "streaming_common/encoder.hpp"
 #include "streaming_common/frame_data.hpp"
-#include "streaming_common/pipeline_stats.hpp"
+#ifdef STREAMING_PIPELINE_STATS
+# include "streaming_common/pipeline_stats.hpp"
+#endif
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -12,7 +14,9 @@
 
 #include <glm/glm.hpp>
 
-#include <chrono>
+#ifdef STREAMING_PIPELINE_STATS
+# include <chrono>
+#endif
 #include <cstdint>
 #include <fstream>
 #include <memory>
@@ -55,7 +59,9 @@ private:
   std::unique_ptr<gp::gl::BufferObject> indices_buffer_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
 
+#ifdef STREAMING_PIPELINE_STATS
   std::chrono::microseconds last_render_us_{};
   EncodeStats encode_stats_{};
+#endif
 };
 } // namespace streaming

--- a/streaming/streaming_encode_decode/encode_scene.hpp
+++ b/streaming/streaming_encode_decode/encode_scene.hpp
@@ -2,6 +2,7 @@
 
 #include "streaming_common/encoder.hpp"
 #include "streaming_common/frame_data.hpp"
+#include "streaming_common/pipeline_stats.hpp"
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -11,6 +12,7 @@
 
 #include <glm/glm.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <fstream>
 #include <memory>
@@ -52,5 +54,8 @@ private:
   std::unique_ptr<gp::gl::BufferObject> vertex_buffer_{};
   std::unique_ptr<gp::gl::BufferObject> indices_buffer_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
+
+  std::chrono::microseconds last_render_us_{};
+  EncodeStats encode_stats_{};
 };
 } // namespace streaming

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -7,6 +7,7 @@
 #include <gp/misc/event.hpp>
 
 #include <array>
+#include <chrono>
 
 namespace streaming {
 namespace {
@@ -86,8 +87,9 @@ void DecodeScene::decode() {
 
   const auto status = decoder_->decode();
   switch (status.code) {
-  case Decoder::Status::Code::OK:
-    printf("Decoding: decoded frame: %i\n", status.frame_num);
+  case Decoder::Status::Code::OK: {
+    using Clock = std::chrono::steady_clock;
+    const auto t0 = Clock::now();
     frame_texture_->bind();
     frame_texture_->set_image(0,
                               format,
@@ -97,10 +99,16 @@ void DecodeScene::decode() {
                               format,
                               GL_UNSIGNED_BYTE,
                               rgb_frame_->data());
+    const auto t1 = Clock::now();
+    const auto &dec_t = decoder_->last_timings();
+    pending_decode_frame_ = {.upload_us = dec_t.upload_us,
+                             .receive_us = dec_t.receive_us,
+                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us,
+                             .texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)};
     frame_ready_ = true;
     break;
+  }
   case Decoder::Status::Code::RETRY:
-    printf("Decoding: packet sent, retrying...\n");
     break;
   case Decoder::Status::Code::EOS:
     printf("Decoding: end of stream\n");
@@ -120,12 +128,19 @@ bool DecodeScene::redraw() {
     return false;
   }
 
+  using Clock = std::chrono::steady_clock;
+  const auto t0 = Clock::now();
+
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glActiveTexture(GL_TEXTURE0);
   shader_program_->use();
   frame_texture_->bind();
   vao_->bind();
   glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+  pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+  decode_stats_.record(pending_decode_frame_);
+
   frame_ready_ = false;
   return true;
 }

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -88,8 +88,10 @@ void DecodeScene::decode() {
   const auto status = decoder_->decode();
   switch (status.code) {
   case Decoder::Status::Code::OK: {
+#ifdef STREAMING_PIPELINE_STATS
     using Clock = std::chrono::steady_clock;
     const auto t0 = Clock::now();
+#endif
     frame_texture_->bind();
     frame_texture_->set_image(0,
                               format,
@@ -99,12 +101,14 @@ void DecodeScene::decode() {
                               format,
                               GL_UNSIGNED_BYTE,
                               rgb_frame_->data());
+#ifdef STREAMING_PIPELINE_STATS
     const auto t1 = Clock::now();
     const auto &dec_t = decoder_->last_timings();
     pending_decode_frame_ = {.upload_us = dec_t.upload_us,
                              .receive_us = dec_t.receive_us,
                              .yuv_to_rgb_us = dec_t.yuv_to_rgb_us,
                              .texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)};
+#endif
     frame_ready_ = true;
     break;
   }
@@ -128,8 +132,10 @@ bool DecodeScene::redraw() {
     return false;
   }
 
+#ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
   const auto t0 = Clock::now();
+#endif
 
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glActiveTexture(GL_TEXTURE0);
@@ -138,8 +144,10 @@ bool DecodeScene::redraw() {
   vao_->bind();
   glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
+#ifdef STREAMING_PIPELINE_STATS
   pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
   decode_stats_.record(pending_decode_frame_);
+#endif
 
   frame_ready_ = false;
   return true;

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -38,6 +38,8 @@ void DecodeScene::set_event_callback(std::function<void(const gp::misc::Event &e
 
 #ifdef STREAMING_PIPELINE_STATS
 void DecodeScene::set_stats_log(std::FILE *const out) noexcept { decode_stats_.set_output(out); }
+
+void DecodeScene::set_max_stats_reports(const uint32_t n) noexcept { decode_stats_.set_max_reports(n); }
 #endif
 
 void DecodeScene::loop(const gp::misc::Event &event) {
@@ -150,7 +152,9 @@ bool DecodeScene::redraw() {
 
 #ifdef STREAMING_PIPELINE_STATS
   pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
-  decode_stats_.record(pending_decode_frame_);
+  if (decode_stats_.record(pending_decode_frame_)) {
+    request_close();
+  }
 #endif
 
   frame_ready_ = false;

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -36,6 +36,10 @@ void DecodeScene::set_event_callback(std::function<void(const gp::misc::Event &e
   event_callback_ = std::move(event_callback);
 }
 
+#ifdef STREAMING_PIPELINE_STATS
+void DecodeScene::set_stats_log(std::FILE *const out) noexcept { decode_stats_.set_output(out); }
+#endif
+
 void DecodeScene::loop(const gp::misc::Event &event) {
   switch (event.type()) {
   case gp::misc::Event::Type::Init:

--- a/streaming/streaming_receiver/decode_scene.hpp
+++ b/streaming/streaming_receiver/decode_scene.hpp
@@ -28,6 +28,10 @@ public:
 
   void set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback);
 
+#ifdef STREAMING_PIPELINE_STATS
+  void set_stats_log(std::FILE *out) noexcept;
+#endif
+
 private:
   void init(const int width, const int height, const std::string &title);
 

--- a/streaming/streaming_receiver/decode_scene.hpp
+++ b/streaming/streaming_receiver/decode_scene.hpp
@@ -2,6 +2,7 @@
 
 #include "streaming_common/decoder.hpp"
 #include "streaming_common/frame_data.hpp"
+#include "streaming_common/pipeline_stats.hpp"
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -52,5 +53,8 @@ private:
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
 
   std::function<void(const gp::misc::Event &event)> event_callback_{};
+
+  DecodeStats::Frame pending_decode_frame_{};
+  DecodeStats decode_stats_{};
 };
 } // namespace streaming

--- a/streaming/streaming_receiver/decode_scene.hpp
+++ b/streaming/streaming_receiver/decode_scene.hpp
@@ -30,6 +30,7 @@ public:
 
 #ifdef STREAMING_PIPELINE_STATS
   void set_stats_log(std::FILE *out) noexcept;
+  void set_max_stats_reports(uint32_t n) noexcept;
 #endif
 
 private:

--- a/streaming/streaming_receiver/decode_scene.hpp
+++ b/streaming/streaming_receiver/decode_scene.hpp
@@ -2,7 +2,9 @@
 
 #include "streaming_common/decoder.hpp"
 #include "streaming_common/frame_data.hpp"
-#include "streaming_common/pipeline_stats.hpp"
+#ifdef STREAMING_PIPELINE_STATS
+# include "streaming_common/pipeline_stats.hpp"
+#endif
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -54,7 +56,9 @@ private:
 
   std::function<void(const gp::misc::Event &event)> event_callback_{};
 
+#ifdef STREAMING_PIPELINE_STATS
   DecodeStats::Frame pending_decode_frame_{};
   DecodeStats decode_stats_{};
+#endif
 };
 } // namespace streaming

--- a/streaming/streaming_receiver/main.cpp
+++ b/streaming/streaming_receiver/main.cpp
@@ -6,6 +6,7 @@
 #include <boost/program_options.hpp>
 
 #include <cstdint>
+#include <cstdio>
 #include <iostream>
 #include <string>
 
@@ -14,6 +15,9 @@ struct ProgramSetup {
 
   std::string ip{};
   std::uint16_t port{};
+#ifdef STREAMING_PIPELINE_STATS
+  std::string stats_log{};
+#endif
 };
 
 ProgramSetup process_args(const int argc, const char *const argv[]) {
@@ -21,6 +25,11 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
   desc.add_options()("help", "This help message");
   desc.add_options()("ip", boost::program_options::value<std::string>()->default_value("127.0.0.1"), "Server ip");
   desc.add_options()("port", boost::program_options::value<std::uint16_t>()->default_value(11100u), "Server port");
+#ifdef STREAMING_PIPELINE_STATS
+  desc.add_options()("stats-log",
+                     boost::program_options::value<std::string>()->default_value(""),
+                     "File path for pipeline stats log (empty = stdout)");
+#endif
 
   boost::program_options::variables_map vm;
   boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
@@ -31,7 +40,11 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
     return {true};
   }
 
+#ifdef STREAMING_PIPELINE_STATS
+  return {false, vm["ip"].as<std::string>(), vm["port"].as<std::uint16_t>(), vm["stats-log"].as<std::string>()};
+#else
   return {false, vm["ip"].as<std::string>(), vm["port"].as<std::uint16_t>()};
+#endif
 }
 
 int main(int argc, char *argv[]) {
@@ -51,8 +64,24 @@ int main(int argc, char *argv[]) {
       [&decode_scene](const std::byte *data, const std::size_t size) { decode_scene->consume_data(data, size); });
   decode_scene->set_event_callback([&receiver](const gp::misc::Event &event) { receiver->handle_event(event); });
 
+#ifdef STREAMING_PIPELINE_STATS
+  std::FILE *stats_file{nullptr};
+  if (!program_setup.stats_log.empty()) {
+    stats_file = std::fopen(program_setup.stats_log.c_str(), "w");
+  }
+  decode_scene->set_stats_log(stats_file != nullptr ? stats_file : stdout);
+#endif
+
   receiver->connect();
 
   const auto async_init = true;
-  return decode_scene->exec(async_init);
+  const auto result = decode_scene->exec(async_init);
+
+#ifdef STREAMING_PIPELINE_STATS
+  if (stats_file != nullptr) {
+    std::fclose(stats_file);
+  }
+#endif
+
+  return result;
 }

--- a/streaming/streaming_receiver/main.cpp
+++ b/streaming/streaming_receiver/main.cpp
@@ -17,6 +17,7 @@ struct ProgramSetup {
   std::uint16_t port{};
 #ifdef STREAMING_PIPELINE_STATS
   std::string stats_log{};
+  uint32_t stats_reports{20};
 #endif
 };
 
@@ -29,6 +30,9 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
   desc.add_options()("stats-log",
                      boost::program_options::value<std::string>()->default_value(""),
                      "File path for pipeline stats log (empty = stdout)");
+  desc.add_options()("stats-reports",
+                     boost::program_options::value<uint32_t>()->default_value(20u),
+                     "Number of stat reports before auto-close (0 = unlimited)");
 #endif
 
   boost::program_options::variables_map vm;
@@ -41,7 +45,11 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
   }
 
 #ifdef STREAMING_PIPELINE_STATS
-  return {false, vm["ip"].as<std::string>(), vm["port"].as<std::uint16_t>(), vm["stats-log"].as<std::string>()};
+  return {false,
+          vm["ip"].as<std::string>(),
+          vm["port"].as<std::uint16_t>(),
+          vm["stats-log"].as<std::string>(),
+          vm["stats-reports"].as<uint32_t>()};
 #else
   return {false, vm["ip"].as<std::string>(), vm["port"].as<std::uint16_t>()};
 #endif
@@ -70,6 +78,7 @@ int main(int argc, char *argv[]) {
     stats_file = std::fopen(program_setup.stats_log.c_str(), "w");
   }
   decode_scene->set_stats_log(stats_file != nullptr ? stats_file : stdout);
+  decode_scene->set_max_stats_reports(program_setup.stats_reports);
 #endif
 
   receiver->connect();

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -85,7 +85,9 @@ void EncodeScene::handle_event(const gp::misc::Event &event) {
 }
 
 #ifdef STREAMING_PIPELINE_STATS
-void EncodeScene::set_stats_log(std::FILE *const out) noexcept { encode_stats_.set_output(out); }
+void EncodeScene::set_stats_log_dir(std::string base_dir) noexcept {
+  encode_stats_.set_output_dir(std::move(base_dir), "streamer.log");
+}
 #endif
 
 void EncodeScene::initialize() {

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -84,6 +84,10 @@ void EncodeScene::handle_event(const gp::misc::Event &event) {
   event_queue_.emplace_back(event);
 }
 
+#ifdef STREAMING_PIPELINE_STATS
+void EncodeScene::set_stats_log(std::FILE *const out) noexcept { encode_stats_.set_output(out); }
+#endif
+
 void EncodeScene::initialize() {
   video_frame_ = encoder_->video_frame();
   init_scene();

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -120,8 +120,10 @@ void EncodeScene::animate(const std::uint64_t time_elapsed_ms) {
 }
 
 void EncodeScene::redraw() {
+#ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
   const auto t0 = Clock::now();
+#endif
 
   auto camera_rot_mat = glm::rotate(glm::mat4(1.0f), glm::radians(camera_rot_.x), glm::vec3(1.0f, 0.0f, 0.0f));
   camera_rot_mat = glm::rotate(camera_rot_mat, glm::radians(camera_rot_.y), glm::vec3(0.0f, 1.0f, 0.0f));
@@ -138,25 +140,33 @@ void EncodeScene::redraw() {
   vao_->bind();
   glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, nullptr);
 
+#ifdef STREAMING_PIPELINE_STATS
   last_render_us_ = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+#endif
 }
 
 void EncodeScene::encode() {
   constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
 
+#ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
 
   const auto t0 = Clock::now();
+#endif
   glReadPixels(0, 0, width(), height(), format, GL_UNSIGNED_BYTE, video_frame_->data());
+#ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();
+#endif
   encoder_->encode();
 
+#ifdef STREAMING_PIPELINE_STATS
   const auto &enc_t = encoder_->last_timings();
   encode_stats_.record({.render_us = last_render_us_,
                         .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
                         .flip_us = enc_t.flip_us,
                         .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
                         .encode_us = enc_t.encode_us});
+#endif
 }
 
 void EncodeScene::init_scene() {

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -10,6 +10,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include <array>
+#include <chrono>
 
 namespace streaming {
 namespace {
@@ -119,6 +120,9 @@ void EncodeScene::animate(const std::uint64_t time_elapsed_ms) {
 }
 
 void EncodeScene::redraw() {
+  using Clock = std::chrono::steady_clock;
+  const auto t0 = Clock::now();
+
   auto camera_rot_mat = glm::rotate(glm::mat4(1.0f), glm::radians(camera_rot_.x), glm::vec3(1.0f, 0.0f, 0.0f));
   camera_rot_mat = glm::rotate(camera_rot_mat, glm::radians(camera_rot_.y), glm::vec3(0.0f, 1.0f, 0.0f));
   camera_rot_mat = glm::rotate(camera_rot_mat, glm::radians(camera_rot_.z), glm::vec3(0.0f, 0.0f, 1.0f));
@@ -133,12 +137,26 @@ void EncodeScene::redraw() {
 
   vao_->bind();
   glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, nullptr);
+
+  last_render_us_ = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
 }
 
 void EncodeScene::encode() {
   constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
+
+  using Clock = std::chrono::steady_clock;
+
+  const auto t0 = Clock::now();
   glReadPixels(0, 0, width(), height(), format, GL_UNSIGNED_BYTE, video_frame_->data());
+  const auto t1 = Clock::now();
   encoder_->encode();
+
+  const auto &enc_t = encoder_->last_timings();
+  encode_stats_.record({.render_us = last_render_us_,
+                        .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
+                        .flip_us = enc_t.flip_us,
+                        .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
+                        .encode_us = enc_t.encode_us});
 }
 
 void EncodeScene::init_scene() {

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -85,9 +85,7 @@ void EncodeScene::handle_event(const gp::misc::Event &event) {
 }
 
 #ifdef STREAMING_PIPELINE_STATS
-void EncodeScene::set_stats_log_dir(std::string base_dir) noexcept {
-  encode_stats_.set_output_dir(std::move(base_dir), "streamer.log");
-}
+void EncodeScene::set_stats_log(std::FILE *const out) noexcept { encode_stats_.set_output(out); }
 #endif
 
 void EncodeScene::initialize() {

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -28,6 +28,8 @@ EncodeScene::EncodeScene(const VideoStreamInfo &video_stream_info)
 
 std::shared_ptr<Encoder> EncodeScene::encoder() const { return encoder_; }
 
+void EncodeScene::close() { request_close(); }
+
 void EncodeScene::loop(const gp::misc::Event &event) {
   switch (event.type()) {
   case gp::misc::Event::Type::Init:

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -28,7 +28,7 @@ EncodeScene::EncodeScene(const VideoStreamInfo &video_stream_info)
 
 std::shared_ptr<Encoder> EncodeScene::encoder() const { return encoder_; }
 
-void EncodeScene::close() { request_close(); }
+void EncodeScene::close() { close_requested_.store(true); }
 
 void EncodeScene::loop(const gp::misc::Event &event) {
   switch (event.type()) {
@@ -41,6 +41,10 @@ void EncodeScene::loop(const gp::misc::Event &event) {
     break;
   case gp::misc::Event::Type::Redraw: {
     process_event_queue();
+    if (close_requested_.load()) {
+      request_close();
+      break;
+    }
     const auto time_elapsed_ms = event.timestamp() - last_timestamp_ms_;
     if (time_elapsed_ms >= ms_per_frame_) {
       animate(time_elapsed_ms);

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -114,8 +114,7 @@ void EncodeScene::animate(const std::uint64_t time_elapsed_ms) {
     return;
   }
 
-  const auto speed_factor = 0.05f;
-  camera_rot_.x += time_elapsed_ms * speed_factor;
+  const auto speed_factor = 0.02f;
   camera_rot_.y += time_elapsed_ms * speed_factor;
 }
 

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -51,7 +51,7 @@ private:
 
   std::shared_ptr<FrameData> video_frame_{};
 
-  bool animate_{};
+  bool animate_{true};
   glm::mat4 projection_{};
   glm::vec3 camera_pos_{};
   glm::vec3 camera_rot_{};

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -30,6 +30,7 @@ public:
 
   std::shared_ptr<Encoder> encoder() const;
   void handle_event(const gp::misc::Event &event);
+  void close();
 
 #ifdef STREAMING_PIPELINE_STATS
   void set_stats_log(std::FILE *out) noexcept;

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -17,6 +17,7 @@
 #ifdef STREAMING_PIPELINE_STATS
 # include <chrono>
 #endif
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -68,6 +69,8 @@ private:
 
   std::vector<gp::misc::Event> event_queue_{};
   std::mutex event_queue_mutex_{};
+
+  std::atomic<bool> close_requested_{false};
 
 #ifdef STREAMING_PIPELINE_STATS
   std::chrono::microseconds last_render_us_{};

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -2,6 +2,7 @@
 
 #include "streaming_common/encoder.hpp"
 #include "streaming_common/frame_data.hpp"
+#include "streaming_common/pipeline_stats.hpp"
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -11,6 +12,7 @@
 
 #include <glm/glm.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -57,5 +59,8 @@ private:
 
   std::vector<gp::misc::Event> event_queue_{};
   std::mutex event_queue_mutex_{};
+
+  std::chrono::microseconds last_render_us_{};
+  EncodeStats encode_stats_{};
 };
 } // namespace streaming

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -32,7 +32,7 @@ public:
   void handle_event(const gp::misc::Event &event);
 
 #ifdef STREAMING_PIPELINE_STATS
-  void set_stats_log_dir(std::string base_dir) noexcept;
+  void set_stats_log(std::FILE *out) noexcept;
 #endif
 
 private:

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -32,7 +32,7 @@ public:
   void handle_event(const gp::misc::Event &event);
 
 #ifdef STREAMING_PIPELINE_STATS
-  void set_stats_log(std::FILE *out) noexcept;
+  void set_stats_log_dir(std::string base_dir) noexcept;
 #endif
 
 private:

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -31,6 +31,10 @@ public:
   std::shared_ptr<Encoder> encoder() const;
   void handle_event(const gp::misc::Event &event);
 
+#ifdef STREAMING_PIPELINE_STATS
+  void set_stats_log(std::FILE *out) noexcept;
+#endif
+
 private:
   void init(const int width, const int height, const std::string &title);
 

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -2,7 +2,9 @@
 
 #include "streaming_common/encoder.hpp"
 #include "streaming_common/frame_data.hpp"
-#include "streaming_common/pipeline_stats.hpp"
+#ifdef STREAMING_PIPELINE_STATS
+# include "streaming_common/pipeline_stats.hpp"
+#endif
 #include "streaming_common/video_stream_info.hpp"
 
 #include <gp/gl/buffer_object.hpp>
@@ -12,7 +14,9 @@
 
 #include <glm/glm.hpp>
 
-#include <chrono>
+#ifdef STREAMING_PIPELINE_STATS
+# include <chrono>
+#endif
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -60,7 +64,9 @@ private:
   std::vector<gp::misc::Event> event_queue_{};
   std::mutex event_queue_mutex_{};
 
+#ifdef STREAMING_PIPELINE_STATS
   std::chrono::microseconds last_render_us_{};
   EncodeStats encode_stats_{};
+#endif
 };
 } // namespace streaming

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -9,10 +9,8 @@
 
 #include <boost/program_options.hpp>
 
-#include <cerrno>
 #include <cstdint>
 #include <cstdio>
-#include <cstring>
 #include <iostream>
 #include <string>
 
@@ -26,7 +24,7 @@ struct ProgramSetup {
   std::uint16_t fps{};
   AVCodecID codec_id{AV_CODEC_ID_NONE};
 #ifdef STREAMING_PIPELINE_STATS
-  std::string stats_log{};
+  std::string stats_log_dir{};
 #endif
 };
 
@@ -44,9 +42,9 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
                      boost::program_options::value<std::string>()->default_value("h264"),
                      "Codec name, e.g. h264 or mpeg4");
 #ifdef STREAMING_PIPELINE_STATS
-  desc.add_options()("stats-log",
+  desc.add_options()("stats-log-dir",
                      boost::program_options::value<std::string>()->default_value(""),
-                     "File path for pipeline stats log (empty = stdout)");
+                     "Base directory for pipeline stats logs (empty = stdout)");
 #endif
 
   boost::program_options::variables_map vm;
@@ -67,7 +65,7 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
           gp::ffmpeg::codec_name_to_id(vm["codec"].as<std::string>())
 #ifdef STREAMING_PIPELINE_STATS
               ,
-          vm["stats-log"].as<std::string>()
+          vm["stats-log-dir"].as<std::string>()
 #endif
   };
 }
@@ -90,31 +88,15 @@ int main(int argc, char *argv[]) {
   auto streamer = std::make_shared<streaming::Streamer>(program_setup.ip, program_setup.port);
 
 #ifdef STREAMING_PIPELINE_STATS
-  std::FILE *stats_file{nullptr};
-  if (!program_setup.stats_log.empty()) {
-    stats_file = std::fopen(program_setup.stats_log.c_str(), "a");
-    if (stats_file == nullptr) {
-      std::fprintf(stderr,
-                   "[streamer] WARNING: failed to open stats log '%s': %s\n",
-                   program_setup.stats_log.c_str(),
-                   std::strerror(errno));
-    } else {
-      std::fprintf(stderr, "[streamer] stats log: %s\n", program_setup.stats_log.c_str());
-    }
+  if (!program_setup.stats_log_dir.empty()) {
+    encode_scene->set_stats_log_dir(program_setup.stats_log_dir);
   }
-  encode_scene->set_stats_log(stats_file != nullptr ? stats_file : stdout);
 #endif
 
   streamer->set_event_callback([&encode_scene](const gp::misc::Event &event) { encode_scene->handle_event(event); });
   streamer->start(encode_scene->encoder());
 
   const auto result = encode_scene->exec();
-
-#ifdef STREAMING_PIPELINE_STATS
-  if (stats_file != nullptr) {
-    std::fclose(stats_file);
-  }
-#endif
 
   return result;
 }

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -9,8 +9,10 @@
 
 #include <boost/program_options.hpp>
 
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <string>
 
@@ -91,6 +93,14 @@ int main(int argc, char *argv[]) {
   std::FILE *stats_file{nullptr};
   if (!program_setup.stats_log.empty()) {
     stats_file = std::fopen(program_setup.stats_log.c_str(), "a");
+    if (stats_file == nullptr) {
+      std::fprintf(stderr,
+                   "[streamer] WARNING: failed to open stats log '%s': %s\n",
+                   program_setup.stats_log.c_str(),
+                   std::strerror(errno));
+    } else {
+      std::fprintf(stderr, "[streamer] stats log: %s\n", program_setup.stats_log.c_str());
+    }
   }
   encode_scene->set_stats_log(stats_file != nullptr ? stats_file : stdout);
 #endif

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -10,6 +10,7 @@
 #include <boost/program_options.hpp>
 
 #include <cstdint>
+#include <cstdio>
 #include <iostream>
 #include <string>
 
@@ -21,8 +22,10 @@ struct ProgramSetup {
   int width{};
   int height{};
   std::uint16_t fps{};
-
   AVCodecID codec_id{AV_CODEC_ID_NONE};
+#ifdef STREAMING_PIPELINE_STATS
+  std::string stats_log{};
+#endif
 };
 
 ProgramSetup process_args(const int argc, const char *const argv[]) {
@@ -38,6 +41,11 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
   desc.add_options()("codec",
                      boost::program_options::value<std::string>()->default_value("h264"),
                      "Codec name, e.g. h264 or mpeg4");
+#ifdef STREAMING_PIPELINE_STATS
+  desc.add_options()("stats-log",
+                     boost::program_options::value<std::string>()->default_value(""),
+                     "File path for pipeline stats log (empty = stdout)");
+#endif
 
   boost::program_options::variables_map vm;
   boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
@@ -54,7 +62,12 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
           vm["width"].as<int>(),
           vm["height"].as<int>(),
           vm["fps"].as<std::uint16_t>(),
-          gp::ffmpeg::codec_name_to_id(vm["codec"].as<std::string>())};
+          gp::ffmpeg::codec_name_to_id(vm["codec"].as<std::string>())
+#ifdef STREAMING_PIPELINE_STATS
+              ,
+          vm["stats-log"].as<std::string>()
+#endif
+  };
 }
 
 int main(int argc, char *argv[]) {
@@ -74,8 +87,24 @@ int main(int argc, char *argv[]) {
   auto encode_scene = std::make_unique<streaming::EncodeScene>(video_stream_info);
   auto streamer = std::make_shared<streaming::Streamer>(program_setup.ip, program_setup.port);
 
+#ifdef STREAMING_PIPELINE_STATS
+  std::FILE *stats_file{nullptr};
+  if (!program_setup.stats_log.empty()) {
+    stats_file = std::fopen(program_setup.stats_log.c_str(), "a");
+  }
+  encode_scene->set_stats_log(stats_file != nullptr ? stats_file : stdout);
+#endif
+
   streamer->set_event_callback([&encode_scene](const gp::misc::Event &event) { encode_scene->handle_event(event); });
   streamer->start(encode_scene->encoder());
 
-  return encode_scene->exec();
+  const auto result = encode_scene->exec();
+
+#ifdef STREAMING_PIPELINE_STATS
+  if (stats_file != nullptr) {
+    std::fclose(stats_file);
+  }
+#endif
+
+  return result;
 }

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -96,6 +96,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   streamer->set_event_callback([&encode_scene](const gp::misc::Event &event) { encode_scene->handle_event(event); });
+  streamer->set_close_callback([&encode_scene]() { encode_scene->close(); });
   streamer->start(encode_scene->encoder());
 
   const auto result = encode_scene->exec();

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -24,7 +24,7 @@ struct ProgramSetup {
   std::uint16_t fps{};
   AVCodecID codec_id{AV_CODEC_ID_NONE};
 #ifdef STREAMING_PIPELINE_STATS
-  std::string stats_log_dir{};
+  std::string stats_log{};
 #endif
 };
 
@@ -42,9 +42,9 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
                      boost::program_options::value<std::string>()->default_value("h264"),
                      "Codec name, e.g. h264 or mpeg4");
 #ifdef STREAMING_PIPELINE_STATS
-  desc.add_options()("stats-log-dir",
+  desc.add_options()("stats-log",
                      boost::program_options::value<std::string>()->default_value(""),
-                     "Base directory for pipeline stats logs (empty = stdout)");
+                     "File path for pipeline stats log (empty = stdout)");
 #endif
 
   boost::program_options::variables_map vm;
@@ -65,7 +65,7 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
           gp::ffmpeg::codec_name_to_id(vm["codec"].as<std::string>())
 #ifdef STREAMING_PIPELINE_STATS
               ,
-          vm["stats-log-dir"].as<std::string>()
+          vm["stats-log"].as<std::string>()
 #endif
   };
 }
@@ -88,15 +88,23 @@ int main(int argc, char *argv[]) {
   auto streamer = std::make_shared<streaming::Streamer>(program_setup.ip, program_setup.port);
 
 #ifdef STREAMING_PIPELINE_STATS
-  if (!program_setup.stats_log_dir.empty()) {
-    encode_scene->set_stats_log_dir(program_setup.stats_log_dir);
+  std::FILE *stats_file{nullptr};
+  if (!program_setup.stats_log.empty()) {
+    stats_file = std::fopen(program_setup.stats_log.c_str(), "a");
   }
+  encode_scene->set_stats_log(stats_file != nullptr ? stats_file : stdout);
 #endif
 
   streamer->set_event_callback([&encode_scene](const gp::misc::Event &event) { encode_scene->handle_event(event); });
   streamer->start(encode_scene->encoder());
 
   const auto result = encode_scene->exec();
+
+#ifdef STREAMING_PIPELINE_STATS
+  if (stats_file != nullptr) {
+    std::fclose(stats_file);
+  }
+#endif
 
   return result;
 }

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -34,6 +34,8 @@ void Streamer::set_event_callback(std::function<void(const gp::misc::Event &even
   event_callback_ = std::move(event_callback);
 }
 
+void Streamer::set_close_callback(std::function<void()> close_callback) { close_callback_ = std::move(close_callback); }
+
 void Streamer::init_web_socket(std::shared_ptr<rtc::WebSocket> web_socket) {
   auto weak_self = weak_from_this();
   web_socket->onOpen([weak_self]() {
@@ -178,6 +180,9 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
     printf("Peer state: Closed\n");
     std::lock_guard<std::mutex> lock(mutex_);
     peer_ = nullptr;
+    if (close_callback_) {
+      close_callback_();
+    }
     break;
   }
 

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -166,14 +166,24 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
     break;
   case rtc::PeerConnection::State::Disconnected: {
     printf("Peer state: Disconnected\n");
-    std::lock_guard<std::mutex> lock(mutex_);
-    peer_ = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      peer_ = nullptr;
+    }
+    if (close_callback_) {
+      close_callback_();
+    }
     break;
   }
   case rtc::PeerConnection::State::Failed: {
     printf("Peer state: Failed\n");
-    std::lock_guard<std::mutex> lock(mutex_);
-    peer_ = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      peer_ = nullptr;
+    }
+    if (close_callback_) {
+      close_callback_();
+    }
     break;
   }
   case rtc::PeerConnection::State::Closed: {

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -166,10 +166,6 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
     break;
   case rtc::PeerConnection::State::Disconnected: {
     printf("Peer state: Disconnected\n");
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      peer_ = nullptr;
-    }
     if (close_callback_) {
       close_callback_();
     }
@@ -177,10 +173,6 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
   }
   case rtc::PeerConnection::State::Failed: {
     printf("Peer state: Failed\n");
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      peer_ = nullptr;
-    }
     if (close_callback_) {
       close_callback_();
     }
@@ -188,10 +180,6 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
   }
   case rtc::PeerConnection::State::Closed: {
     printf("Peer state: Closed\n");
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      peer_ = nullptr;
-    }
     if (close_callback_) {
       close_callback_();
     }

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -178,8 +178,10 @@ void Streamer::on_peer_state_change(rtc::PeerConnection::State state) {
   }
   case rtc::PeerConnection::State::Closed: {
     printf("Peer state: Closed\n");
-    std::lock_guard<std::mutex> lock(mutex_);
-    peer_ = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      peer_ = nullptr;
+    }
     if (close_callback_) {
       close_callback_();
     }

--- a/streaming/streaming_streamer/streamer.hpp
+++ b/streaming/streaming_streamer/streamer.hpp
@@ -26,6 +26,7 @@ public:
 
   void start(std::shared_ptr<Encoder> encoder);
   void set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback);
+  void set_close_callback(std::function<void()> close_callback);
 
 private:
   struct Peer {
@@ -65,5 +66,6 @@ private:
   std::shared_ptr<Peer> peer_{};
   mutable std::mutex mutex_{};
   std::function<void(const gp::misc::Event &event)> event_callback_{};
+  std::function<void()> close_callback_{};
 };
 } // namespace streaming


### PR DESCRIPTION
Closes #188

## Changes

### New: `streaming_common/pipeline_stats.hpp`
- `StageStats`: min/max/avg accumulator for one pipeline stage
- `EncodeStats`: records render, capture, flip, rgb→yuv, encode per-frame; prints report every 100 frames
- `DecodeStats`: records upload, receive, yuv→rgb, texture-upload, display per-frame; prints report every 100 frames

### `Encoder` (streaming_common)
- Added `Encoder::Timings` struct with `flip_us`, `rgb_to_yuv_us`, `encode_us`
- `encode()` now timestamps each sub-stage; results available via `last_timings()`

### `Decoder` (streaming_common)
- Added `Decoder::Timings` struct with `upload_us`, `receive_us`, `yuv_to_rgb_us`
- `decode()` now timestamps each sub-stage; results available via `last_timings()`

### Scene classes (all 4)
- `EncodeScene::redraw()`: timestamps GL render; `encode()`: timestamps `glReadPixels`, wires into `EncodeStats`
- `DecodeScene::decode()`: timestamps texture upload, stores `pending_decode_frame_`; `redraw()`: timestamps display, calls `decode_stats_.record()`

### Removed per-frame printf from decode hot paths
Hot-path `printf` calls (decoded frame N, packet sent, retrying) removed from both decode scenes — these were syscalls at 30+ fps.