### PR TITLE
191: Medium priority fixes: sws flags, consume_async_buffer, EOF header, STUN

### DIFF
--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -267,7 +267,7 @@ void Decoder::yuv_to_rgb() {
                                       context_->width,
                                       context_->height,
                                       AV_PIX_FMT_RGBA,
-                                      0,
+                                      SWS_FAST_BILINEAR,
                                       nullptr,
                                       nullptr,
                                       nullptr);
@@ -285,16 +285,14 @@ void Decoder::fill_async_buffer(const std::byte *data, const std::size_t size) {
 }
 
 void Decoder::consume_async_buffer() {
-  const auto lock = std::lock_guard{async_buffer_mutex_};
-
-  if (async_buffer_.empty()) {
-    return;
+  std::vector<std::uint8_t> local;
+  {
+    const auto lock = std::lock_guard{async_buffer_mutex_};
+    if (async_buffer_.empty()) {
+      return;
+    }
+    local.swap(async_buffer_);
   }
-
-  const auto size = async_buffer_.size();
-  const auto data = async_buffer_.data();
-  async_buffer_.clear();
-
-  incoming_data(reinterpret_cast<const std::byte *>(data), size);
+  incoming_data(reinterpret_cast<const std::byte *>(local.data()), local.size());
 }
 } // namespace streaming

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -62,7 +62,7 @@ Encoder::Encoder(const VideoStreamInfo &video_stream_info)
                                     context_->width,
                                     context_->height,
                                     AV_PIX_FMT_YUV420P,
-                                    SWS_BILINEAR,
+                                    SWS_FAST_BILINEAR,
                                     nullptr,
                                     nullptr,
                                     nullptr));

--- a/streaming/streaming_common/stream_package_header.hpp
+++ b/streaming/streaming_common/stream_package_header.hpp
@@ -1,12 +1,42 @@
 #pragma once
 
-#include <cstddef>
+#include <array>
+#include <cstdint>
 
 namespace streaming {
+
+// Wire format (8 bytes, little-endian):
+//   [0..7] frame_num  — uint64, little-endian
+//   [8]    flags      — bit 0 = eof
+constexpr auto STREAM_PACKAGE_HEADER_SIZE = std::size_t{9};
+
 struct StreamPackageHeader {
-  std::size_t frame_num{};
+  std::uint64_t frame_num{};
   bool eof{};
+
+  [[nodiscard]] std::array<std::uint8_t, STREAM_PACKAGE_HEADER_SIZE> serialize() const noexcept {
+    std::array<std::uint8_t, STREAM_PACKAGE_HEADER_SIZE> buf{};
+    buf[0] = static_cast<std::uint8_t>(frame_num >> 0);
+    buf[1] = static_cast<std::uint8_t>(frame_num >> 8);
+    buf[2] = static_cast<std::uint8_t>(frame_num >> 16);
+    buf[3] = static_cast<std::uint8_t>(frame_num >> 24);
+    buf[4] = static_cast<std::uint8_t>(frame_num >> 32);
+    buf[5] = static_cast<std::uint8_t>(frame_num >> 40);
+    buf[6] = static_cast<std::uint8_t>(frame_num >> 48);
+    buf[7] = static_cast<std::uint8_t>(frame_num >> 56);
+    buf[8] = eof ? std::uint8_t{1} : std::uint8_t{0};
+    return buf;
+  }
+
+  static StreamPackageHeader deserialize(const std::uint8_t *buf) noexcept {
+    StreamPackageHeader h{};
+    h.frame_num = (static_cast<std::uint64_t>(buf[0]) << 0) | (static_cast<std::uint64_t>(buf[1]) << 8) |
+                  (static_cast<std::uint64_t>(buf[2]) << 16) | (static_cast<std::uint64_t>(buf[3]) << 24) |
+                  (static_cast<std::uint64_t>(buf[4]) << 32) | (static_cast<std::uint64_t>(buf[5]) << 40) |
+                  (static_cast<std::uint64_t>(buf[6]) << 48) | (static_cast<std::uint64_t>(buf[7]) << 56);
+    h.eof = (buf[8] & 0x01u) != 0u;
+    return h;
+  }
 };
 
-constexpr auto STREAM_PACKAGE_HEADER_SIZE = sizeof(StreamPackageHeader);
 } // namespace streaming

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -27,9 +27,14 @@ void DecodeScene::init(const VideoStreamInfo &video_stream_info) {
   Scene3D::init(video_stream_info.width, video_stream_info.height, "Decoding...", async);
 }
 
-void DecodeScene::consume_data(const std::byte *data, const std::size_t size) {
-  const auto async = true;
-  decoder_->incoming_data(data, size, async);
+void DecodeScene::consume_data(const std::byte *data, const std::size_t size, const bool eof) {
+  if (size > 0) {
+    const auto async = true;
+    decoder_->incoming_data(data, size, async);
+  }
+  if (eof) {
+    decoder_->signal_eof();
+  }
 }
 
 void DecodeScene::set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback) {

--- a/streaming/streaming_receiver/decode_scene.hpp
+++ b/streaming/streaming_receiver/decode_scene.hpp
@@ -24,7 +24,7 @@ public:
   DecodeScene();
 
   void init(const VideoStreamInfo &video_stream_info);
-  void consume_data(const std::byte *data, const std::size_t size);
+  void consume_data(const std::byte *data, const std::size_t size, const bool eof = false);
 
   void set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback);
 

--- a/streaming/streaming_receiver/main.cpp
+++ b/streaming/streaming_receiver/main.cpp
@@ -69,7 +69,9 @@ int main(int argc, char *argv[]) {
   receiver->set_video_stream_info_callback(
       [&decode_scene](const streaming::VideoStreamInfo &video_stream_info) { decode_scene->init(video_stream_info); });
   receiver->set_incoming_video_stream_data_callback(
-      [&decode_scene](const std::byte *data, const std::size_t size) { decode_scene->consume_data(data, size); });
+      [&decode_scene](const std::byte *data, const std::size_t size, const bool eof) {
+        decode_scene->consume_data(data, size, eof);
+      });
   decode_scene->set_event_callback([&receiver](const gp::misc::Event &event) { receiver->handle_event(event); });
 
 #ifdef STREAMING_PIPELINE_STATS

--- a/streaming/streaming_receiver/receiver.cpp
+++ b/streaming/streaming_receiver/receiver.cpp
@@ -6,8 +6,6 @@
 #include <gp/json/misc.hpp>
 #include <gp/utils/utils.hpp>
 
-#include <cstring>
-
 namespace streaming {
 Receiver::Receiver(const std::string &server_ip, const std::uint16_t server_port)
     : receiver_id_{gp::utils::generate_random_string(16u)}
@@ -262,8 +260,7 @@ void Receiver::on_data_channel_binary_message(rtc::binary message) {
     return;
   }
 
-  StreamPackageHeader header{};
-  std::memcpy(&header, message.data(), STREAM_PACKAGE_HEADER_SIZE);
+  StreamPackageHeader header = StreamPackageHeader::deserialize(reinterpret_cast<const std::uint8_t *>(message.data()));
 
   const auto *payload = message.data() + STREAM_PACKAGE_HEADER_SIZE;
   const auto payload_size = message.size() - STREAM_PACKAGE_HEADER_SIZE;

--- a/streaming/streaming_receiver/receiver.cpp
+++ b/streaming/streaming_receiver/receiver.cpp
@@ -1,9 +1,12 @@
 #include "receiver.hpp"
 
 #include "streaming_common/constants.hpp"
+#include "streaming_common/stream_package_header.hpp"
 
 #include <gp/json/misc.hpp>
 #include <gp/utils/utils.hpp>
+
+#include <cstring>
 
 namespace streaming {
 Receiver::Receiver(const std::string &server_ip, const std::uint16_t server_port)
@@ -42,7 +45,8 @@ void Receiver::set_video_stream_info_callback(
 }
 
 void Receiver::set_incoming_video_stream_data_callback(
-    std::function<void(const std::byte *data, const std::size_t size)> incoming_video_stream_data_callback) {
+    std::function<void(const std::byte *data, const std::size_t size, const bool eof)>
+        incoming_video_stream_data_callback) {
   incoming_video_stream_data_callback_ = std::move(incoming_video_stream_data_callback);
 }
 
@@ -254,10 +258,21 @@ void Receiver::on_data_channel_closed() { printf("Data channel closed\n"); }
 void Receiver::on_data_channel_error(std::string error) { printf("Data channel error: %s\n", error.c_str()); }
 
 void Receiver::on_data_channel_binary_message(rtc::binary message) {
-  if (incoming_video_stream_data_callback_) {
-    incoming_video_stream_data_callback_(message.data(), message.size());
-  } else {
-    printf("Incoming video stream data callback not set\n");
+  if (message.size() < STREAM_PACKAGE_HEADER_SIZE) {
+    return;
+  }
+
+  StreamPackageHeader header{};
+  std::memcpy(&header, message.data(), STREAM_PACKAGE_HEADER_SIZE);
+
+  const auto *payload = message.data() + STREAM_PACKAGE_HEADER_SIZE;
+  const auto payload_size = message.size() - STREAM_PACKAGE_HEADER_SIZE;
+
+  if (incoming_video_stream_data_callback_ && payload_size > 0) {
+    incoming_video_stream_data_callback_(payload, payload_size, false);
+  }
+  if (header.eof && incoming_video_stream_data_callback_) {
+    incoming_video_stream_data_callback_(nullptr, 0, true);
   }
 }
 

--- a/streaming/streaming_receiver/receiver.hpp
+++ b/streaming/streaming_receiver/receiver.hpp
@@ -30,7 +30,8 @@ public:
   void set_video_stream_info_callback(
       std::function<void(const VideoStreamInfo &video_stream_info)> video_stream_info_callback);
   void set_incoming_video_stream_data_callback(
-      std::function<void(const std::byte *data, const std::size_t size)> incoming_video_stream_data_callback);
+      std::function<void(const std::byte *data, const std::size_t size, const bool eof)>
+          incoming_video_stream_data_callback);
 
 private:
   struct Peer {
@@ -81,6 +82,7 @@ private:
   mutable std::mutex mutex_{};
 
   std::function<void(const VideoStreamInfo &video_stream_info)> video_stream_info_callback_{};
-  std::function<void(const std::byte *data, const std::size_t size)> incoming_video_stream_data_callback_{};
+  std::function<void(const std::byte *data, const std::size_t size, const bool eof)>
+      incoming_video_stream_data_callback_{};
 };
 } // namespace streaming

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -23,6 +23,7 @@ struct ProgramSetup {
   int height{};
   std::uint16_t fps{};
   AVCodecID codec_id{AV_CODEC_ID_NONE};
+  bool use_stun{true};
 #ifdef STREAMING_PIPELINE_STATS
   std::string stats_log{};
 #endif
@@ -41,6 +42,7 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
   desc.add_options()("codec",
                      boost::program_options::value<std::string>()->default_value("h264"),
                      "Codec name, e.g. h264 or mpeg4");
+  desc.add_options()("no-stun", "Disable STUN server (use for local LAN connections)");
 #ifdef STREAMING_PIPELINE_STATS
   desc.add_options()("stats-log",
                      boost::program_options::value<std::string>()->default_value(""),
@@ -62,9 +64,10 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
           vm["width"].as<int>(),
           vm["height"].as<int>(),
           vm["fps"].as<std::uint16_t>(),
-          gp::ffmpeg::codec_name_to_id(vm["codec"].as<std::string>())
+          gp::ffmpeg::codec_name_to_id(vm["codec"].as<std::string>()),
+          !vm.count("no-stun")
 #ifdef STREAMING_PIPELINE_STATS
-              ,
+          ,
           vm["stats-log"].as<std::string>()
 #endif
   };
@@ -85,7 +88,7 @@ int main(int argc, char *argv[]) {
                                                             avcodec_get_name(program_setup.codec_id)};
 
   auto encode_scene = std::make_unique<streaming::EncodeScene>(video_stream_info);
-  auto streamer = std::make_shared<streaming::Streamer>(program_setup.ip, program_setup.port);
+  auto streamer = std::make_shared<streaming::Streamer>(program_setup.ip, program_setup.port, program_setup.use_stun);
 
 #ifdef STREAMING_PIPELINE_STATS
   std::FILE *stats_file{nullptr};

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -2,15 +2,21 @@
 
 #include "streaming_common/constants.hpp"
 #include "streaming_common/encoder.hpp"
+#include "streaming_common/stream_package_header.hpp"
 
 #include <gp/json/misc.hpp>
 #include <gp/utils/utils.hpp>
 
+#include <cstring>
+#include <vector>
+
 namespace streaming {
-Streamer::Streamer(const std::string &server_ip, const std::uint16_t server_port)
+Streamer::Streamer(const std::string &server_ip, const std::uint16_t server_port, const bool use_stun)
     : id_{std::string{STREAMER_ID} + ":" + gp::utils::generate_random_string(16u)}
     , connection_url_{std::string{"ws://"} + server_ip + ":" + std::to_string(server_port) + "/" + id_} {
-  configuration_.iceServers.emplace_back("stun.l.google.com", 19302);
+  if (use_stun) {
+    configuration_.iceServers.emplace_back("stun.l.google.com", 19302);
+  }
   configuration_.disableAutoNegotiation = true;
   configuration_.maxMessageSize = MAX_MESSAGE_SIZE;
 
@@ -287,12 +293,11 @@ void Streamer::video_stream_callback(const std::byte *data, const std::size_t si
     peer = peer_;
   }
   if (peer && peer->data_channel && peer->data_channel->isOpen()) {
-    peer->data_channel->send(data, size);
-    if (eof) {
-      constexpr auto eof_data = "EOF";
-      constexpr auto eof_size = 4u;
-      peer->data_channel->send(reinterpret_cast<const std::byte *>(eof_data), eof_size);
-    }
+    const StreamPackageHeader header{frame_num_++, eof};
+    std::vector<std::byte> packet(STREAM_PACKAGE_HEADER_SIZE + size);
+    std::memcpy(packet.data(), &header, STREAM_PACKAGE_HEADER_SIZE);
+    std::memcpy(packet.data() + STREAM_PACKAGE_HEADER_SIZE, data, size);
+    peer->data_channel->send(packet.data(), packet.size());
   }
 }
 

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -294,8 +294,9 @@ void Streamer::video_stream_callback(const std::byte *data, const std::size_t si
   }
   if (peer && peer->data_channel && peer->data_channel->isOpen()) {
     const StreamPackageHeader header{frame_num_++, eof};
+    const auto serialized = header.serialize();
     std::vector<std::byte> packet(STREAM_PACKAGE_HEADER_SIZE + size);
-    std::memcpy(packet.data(), &header, STREAM_PACKAGE_HEADER_SIZE);
+    std::memcpy(packet.data(), serialized.data(), STREAM_PACKAGE_HEADER_SIZE);
     std::memcpy(packet.data() + STREAM_PACKAGE_HEADER_SIZE, data, size);
     peer->data_channel->send(packet.data(), packet.size());
   }

--- a/streaming/streaming_streamer/streamer.hpp
+++ b/streaming/streaming_streamer/streamer.hpp
@@ -61,7 +61,7 @@ private:
   std::string connection_url_{};
   VideoStreamInfo video_stream_info_{};
   std::atomic<bool> connection_open_{false};
-  std::size_t frame_num_{0};
+  std::uint64_t frame_num_{0};
   rtc::Configuration configuration_{};
   std::shared_ptr<rtc::WebSocket> web_socket_{};
   std::shared_ptr<Peer> peer_{};

--- a/streaming/streaming_streamer/streamer.hpp
+++ b/streaming/streaming_streamer/streamer.hpp
@@ -22,7 +22,7 @@ public:
   Streamer(Streamer &&other) noexcept = delete;
   Streamer &operator=(Streamer &&other) noexcept = delete;
 
-  Streamer(const std::string &server_ip, const std::uint16_t server_port);
+  Streamer(const std::string &server_ip, const std::uint16_t server_port, const bool use_stun = true);
 
   void start(std::shared_ptr<Encoder> encoder);
   void set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback);
@@ -61,6 +61,7 @@ private:
   std::string connection_url_{};
   VideoStreamInfo video_stream_info_{};
   std::atomic<bool> connection_open_{false};
+  std::size_t frame_num_{0};
   rtc::Configuration configuration_{};
   std::shared_ptr<rtc::WebSocket> web_socket_{};
   std::shared_ptr<Peer> peer_{};


### PR DESCRIPTION
Closes #191

## Changes

### decoder.cpp
- Use `SWS_FAST_BILINEAR` in `sws_getCachedContext` (was `0`) — no scaling takes place, only pixel format conversion
- `consume_async_buffer()`: swap `async_buffer_` into a local vector under lock, release lock, then call `incoming_data()` on the local — eliminates double-copy and reduces lock contention

### streamer.cpp / streamer.hpp
- Wrap every outgoing packet with `StreamPackageHeader` (frame_num + eof flag) — replaces the raw `"EOF"` byte string that was being fed into the H.264 decoder
- Add `use_stun` constructor parameter; conditionally add Google STUN ICE server

### receiver.cpp / receiver.hpp
- Parse `StreamPackageHeader` in `on_data_channel_binary_message()`
- Pass `eof` bool to `incoming_video_stream_data_callback_` (signature updated)

### decode_scene.cpp / decode_scene.hpp (streaming_receiver)
- `consume_data()` accepts `bool eof` parameter; calls `decoder_->signal_eof()` when set

### main.cpp (streaming_streamer)
- Add `--no-stun` CLI flag (useful for LAN connections without NAT traversal)