### PR TITLE
190: Async GPU readback via double-buffered PBOs in encode pipeline

### DIFF
--- a/streaming/streaming_encode_decode/encode_scene.cpp
+++ b/streaming/streaming_encode_decode/encode_scene.cpp
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstring>
 
 namespace streaming {
 namespace {
@@ -57,6 +58,9 @@ void EncodeScene::initialize() {
 }
 
 void EncodeScene::finalize() {
+  drain_pbo();
+  pbo_[0].reset();
+  pbo_[1].reset();
   shader_program_.reset();
   indices_buffer_.reset();
   vertex_buffer_.reset();
@@ -103,28 +107,65 @@ void EncodeScene::encode() {
 
 #ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
-
   const auto t0 = Clock::now();
 #endif
-  glReadPixels(0,
-               0,
-               video_stream_info_.width,
-               video_stream_info_.height,
-               format,
-               GL_UNSIGNED_BYTE,
-               video_frame_->data());
+
+  const auto write_idx = pbo_index_;
+  const auto read_idx = 1 - pbo_index_;
+  pbo_index_ = 1 - pbo_index_;
+
+  // Issue async readback for this frame — returns immediately; GPU writes into PBO concurrently
+  pbo_[write_idx]->bind();
+  glReadPixels(0, 0, video_stream_info_.width, video_stream_info_.height, format, GL_UNSIGNED_BYTE, nullptr);
+  pbo_[write_idx]->unbind();
+
+  auto mapped_ok = false;
+  if (pbo_primed_) {
+    // Previous PBO's readback has had a full frame cycle to complete — map and encode
+    pbo_[read_idx]->bind();
+    const auto *src = static_cast<const FrameSubType *>(pbo_[read_idx]->map(GL_READ_ONLY));
+    if (src) {
+      std::memcpy(video_frame_->data(), src, video_frame_->size());
+      pbo_[read_idx]->unmap();
+      mapped_ok = true;
+    }
+    pbo_[read_idx]->unbind();
+  }
+  pbo_primed_ = true;
+
 #ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();
 #endif
-  encoder_->encode();
+
+  if (mapped_ok) {
+    encoder_->encode();
+  }
 
 #ifdef STREAMING_PIPELINE_STATS
-  const auto &enc_t = encoder_->last_timings();
-  encode_stats_.record({.render_us = last_render_us_,
-                        .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
-                        .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
-                        .encode_us = enc_t.encode_us});
+  if (mapped_ok) {
+    const auto &enc_t = encoder_->last_timings();
+    encode_stats_.record({.render_us = last_render_us_,
+                          .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
+                          .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
+                          .encode_us = enc_t.encode_us});
+  }
 #endif
+}
+
+void EncodeScene::drain_pbo() {
+  if (!pbo_primed_) {
+    return;
+  }
+  // The slot written to last is 1 - pbo_index_ (pbo_index_ was already toggled by the last encode() call)
+  const auto read_idx = 1 - pbo_index_;
+  pbo_[read_idx]->bind();
+  const auto *src = static_cast<const FrameSubType *>(pbo_[read_idx]->map(GL_READ_ONLY));
+  if (src) {
+    std::memcpy(video_frame_->data(), src, video_frame_->size());
+    pbo_[read_idx]->unmap();
+    encoder_->encode();
+  }
+  pbo_[read_idx]->unbind();
 }
 
 void EncodeScene::init_streaming() {
@@ -139,6 +180,14 @@ void EncodeScene::init_streaming() {
       });
 
   video_frame_ = encoder_->video_frame();
+
+  const auto frame_size = static_cast<GLsizeiptr>(video_stream_info_.width) * video_stream_info_.height * CHANNELS_NUM;
+  for (auto &pbo : pbo_) {
+    pbo = std::make_unique<gp::gl::BufferObject>(GL_PIXEL_PACK_BUFFER);
+    pbo->bind();
+    pbo->set_data(frame_size, nullptr, GL_STREAM_READ);
+    pbo->unbind();
+  }
 }
 
 void EncodeScene::init_scene() {

--- a/streaming/streaming_encode_decode/encode_scene.hpp
+++ b/streaming/streaming_encode_decode/encode_scene.hpp
@@ -10,6 +10,8 @@
 #include <gp/gl/buffer_object.hpp>
 #include <gp/gl/shader_program.hpp>
 #include <gp/gl/vertex_array_object.hpp>
+
+#include <array>
 #include <gp/sdl/scene_3d.hpp>
 
 #include <glm/glm.hpp>
@@ -34,6 +36,7 @@ private:
 
   void initialize();
   void finalize();
+  void drain_pbo();
   void animate(const std::uint64_t time_elapsed_ms);
   void redraw();
   void encode();
@@ -58,6 +61,10 @@ private:
   std::unique_ptr<gp::gl::BufferObject> vertex_buffer_{};
   std::unique_ptr<gp::gl::BufferObject> indices_buffer_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
+
+  std::array<std::unique_ptr<gp::gl::BufferObject>, 2> pbo_{};
+  int pbo_index_{0};
+  bool pbo_primed_{false};
 
 #ifdef STREAMING_PIPELINE_STATS
   std::chrono::microseconds last_render_us_{};

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstring>
 
 namespace streaming {
 namespace {
@@ -97,9 +98,19 @@ void EncodeScene::set_stats_log(std::FILE *const out) noexcept { encode_stats_.s
 void EncodeScene::initialize() {
   video_frame_ = encoder_->video_frame();
   init_scene();
+
+  const auto frame_size = static_cast<GLsizeiptr>(width()) * height() * CHANNELS_NUM;
+  for (auto &pbo : pbo_) {
+    pbo = std::make_unique<gp::gl::BufferObject>(GL_PIXEL_PACK_BUFFER);
+    pbo->bind();
+    pbo->set_data(frame_size, nullptr, GL_STREAM_READ);
+    pbo->unbind();
+  }
 }
 
 void EncodeScene::finalize() {
+  pbo_[0].reset();
+  pbo_[1].reset();
   shader_program_.reset();
   indices_buffer_.reset();
   vertex_buffer_.reset();
@@ -159,21 +170,48 @@ void EncodeScene::encode() {
 
 #ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
-
   const auto t0 = Clock::now();
 #endif
-  glReadPixels(0, 0, width(), height(), format, GL_UNSIGNED_BYTE, video_frame_->data());
+
+  const auto write_idx = pbo_index_;
+  const auto read_idx = 1 - pbo_index_;
+  pbo_index_ = 1 - pbo_index_;
+
+  // Issue async readback for this frame — returns immediately; GPU writes into PBO concurrently
+  pbo_[write_idx]->bind();
+  glReadPixels(0, 0, width(), height(), format, GL_UNSIGNED_BYTE, nullptr);
+  pbo_[write_idx]->unbind();
+
+  auto mapped_ok = false;
+  if (pbo_primed_) {
+    // Previous PBO's readback has had a full frame cycle to complete — map and encode
+    pbo_[read_idx]->bind();
+    const auto *src = static_cast<const FrameSubType *>(pbo_[read_idx]->map(GL_READ_ONLY));
+    if (src) {
+      std::memcpy(video_frame_->data(), src, video_frame_->size());
+      pbo_[read_idx]->unmap();
+      mapped_ok = true;
+    }
+    pbo_[read_idx]->unbind();
+  }
+  pbo_primed_ = true;
+
 #ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();
 #endif
-  encoder_->encode();
+
+  if (mapped_ok) {
+    encoder_->encode();
+  }
 
 #ifdef STREAMING_PIPELINE_STATS
-  const auto &enc_t = encoder_->last_timings();
-  encode_stats_.record({.render_us = last_render_us_,
-                        .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
-                        .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
-                        .encode_us = enc_t.encode_us});
+  if (mapped_ok) {
+    const auto &enc_t = encoder_->last_timings();
+    encode_stats_.record({.render_us = last_render_us_,
+                          .capture_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0),
+                          .rgb_to_yuv_us = enc_t.rgb_to_yuv_us,
+                          .encode_us = enc_t.encode_us});
+  }
 #endif
 }
 

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -10,6 +10,8 @@
 #include <gp/gl/buffer_object.hpp>
 #include <gp/gl/shader_program.hpp>
 #include <gp/gl/vertex_array_object.hpp>
+
+#include <array>
 #include <gp/sdl/scene_3d.hpp>
 
 #include <glm/glm.hpp>
@@ -66,6 +68,10 @@ private:
   std::unique_ptr<gp::gl::BufferObject> vertex_buffer_{};
   std::unique_ptr<gp::gl::BufferObject> indices_buffer_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
+
+  std::array<std::unique_ptr<gp::gl::BufferObject>, 2> pbo_{};
+  int pbo_index_{0};
+  bool pbo_primed_{false};
 
   std::vector<gp::misc::Event> event_queue_{};
   std::mutex event_queue_mutex_{};


### PR DESCRIPTION
## Motivation

Closes part of #190.

Benchmarking revealed that `glReadPixels` (the capture stage) was the biggest bottleneck in the encode pipeline (~1500–2000 µs per frame). The synchronous call blocks the CPU until the GPU finishes rendering the current frame.

The root cause identified during PR #194 benchmark analysis: removing `flip_frame` (PR #189) saved ~443 µs of CPU work but caused `glReadPixels` to be called ~443 µs earlier — before the GPU had finished — shifting the wait into the capture stat. The total pipeline time was unchanged because the GPU readback latency was always there, hidden by the flip work.

## Solution

Replace synchronous `glReadPixels` with a **double-buffered PBO** scheme:

| Frame | Action |
|-------|--------|
| N | `glReadPixels` into `PBO[N%2]` — returns **immediately**, GPU DMAs async |
| N+1 | Map `PBO[(N+1)%2]` (guaranteed complete) → `memcpy` → encode |

The GPU readback for frame N now overlaps with the CPU's rgb→yuv conversion and H.264 encode of frame N−1. This eliminates the synchronisation stall entirely.

## Changes

- `streaming_encode_decode/encode_scene.cpp/.hpp`
- `streaming_streamer/encode_scene.cpp/.hpp`

Both allocate two `GL_PIXEL_PACK_BUFFER` objects in `initialize()`/`init_streaming()`, rotate between them each frame, and skip encoding on the very first frame (PBO prime). The `capture_us` stat now measures PBO map+memcpy+unmap time instead of a blocking GPU sync.