### PR TITLE
192: streaming: low priority fixes — double-buffer decoded frames, bitrate feedback

### DIFF
--- a/streaming/streaming_common/constants.hpp
+++ b/streaming/streaming_common/constants.hpp
@@ -29,10 +29,11 @@ constexpr auto STREAMER_ID = "streamer";
 constexpr auto RECEIVER_ID = "receiver";
 constexpr auto DATA_CHANNEL_ID = "video-channel";
 
-// Feedback ACK: receiver sends one ACK message every ACK_INTERVAL received frames.
+// Feedback ACK: receiver sends one ACK message every ACK_INTERVAL received DataChannel packets.
 constexpr auto ACK_INTERVAL = std::size_t{10};
 
-// Lag thresholds (in frames) for encoder throttling on the streamer side.
+// Lag thresholds (in DataChannel packets) for encoder throttling on the streamer side.
+// Each encoded frame produces one packet, so packet lag approximates frame lag in normal operation.
 // Above LAG_THROTTLE_HEAVY: encode every 4th frame.
 // Above LAG_THROTTLE_LIGHT: encode every 2nd frame.
 constexpr auto LAG_THROTTLE_LIGHT = std::uint64_t{10};

--- a/streaming/streaming_common/constants.hpp
+++ b/streaming/streaming_common/constants.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace streaming {
 constexpr auto BITRATE_kbits_1 = 1024; // 1 kbit/s in bits/s (binary)
@@ -27,4 +28,13 @@ constexpr auto MAX_MESSAGE_SIZE = 1024u * 1024u; // 1MB
 constexpr auto STREAMER_ID = "streamer";
 constexpr auto RECEIVER_ID = "receiver";
 constexpr auto DATA_CHANNEL_ID = "video-channel";
+
+// Feedback ACK: receiver sends one ACK message every ACK_INTERVAL received frames.
+constexpr auto ACK_INTERVAL = std::size_t{10};
+
+// Lag thresholds (in frames) for encoder throttling on the streamer side.
+// Above LAG_THROTTLE_HEAVY: encode every 4th frame.
+// Above LAG_THROTTLE_LIGHT: encode every 2nd frame.
+constexpr auto LAG_THROTTLE_LIGHT = std::uint64_t{10};
+constexpr auto LAG_THROTTLE_HEAVY = std::uint64_t{30};
 } // namespace streaming

--- a/streaming/streaming_encode_decode/decode_scene.cpp
+++ b/streaming/streaming_encode_decode/decode_scene.cpp
@@ -58,6 +58,7 @@ void DecodeScene::finalize() {
   frame_texture_.reset();
   vertex_buffer_.reset();
   vao_.reset();
+  display_frame_.reset();
   rgb_frame_.reset();
   input_file_.reset();
   decoder_.reset();
@@ -65,36 +66,16 @@ void DecodeScene::finalize() {
 }
 
 void DecodeScene::decode() {
-  constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
-
-  if (frame_ready_) {
-    return;
-  }
-
   const auto status = decoder_->decode();
   switch (status.code) {
   case Decoder::Status::Code::OK: {
 #ifdef STREAMING_PIPELINE_STATS
-    using Clock = std::chrono::steady_clock;
-    const auto t0 = Clock::now();
-#endif
-    frame_texture_->bind();
-    frame_texture_->set_sub_image(0,
-                                  0,
-                                  0,
-                                  video_stream_info_.width,
-                                  video_stream_info_.height,
-                                  format,
-                                  GL_UNSIGNED_BYTE,
-                                  rgb_frame_->data());
-#ifdef STREAMING_PIPELINE_STATS
-    const auto t1 = Clock::now();
     const auto &dec_t = decoder_->last_timings();
     pending_decode_frame_ = {.upload_us = dec_t.upload_us,
                              .receive_us = dec_t.receive_us,
-                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us,
-                             .texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)};
+                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us};
 #endif
+    rgb_frame_->swap(*display_frame_);
     frame_ready_ = true;
     break;
   }
@@ -117,9 +98,27 @@ bool DecodeScene::redraw() {
     return false;
   }
 
+  constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
+
 #ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
   const auto t0 = Clock::now();
+#endif
+
+  frame_texture_->bind();
+  frame_texture_->set_sub_image(0,
+                                0,
+                                0,
+                                video_stream_info_.width,
+                                video_stream_info_.height,
+                                format,
+                                GL_UNSIGNED_BYTE,
+                                display_frame_->data());
+
+#ifdef STREAMING_PIPELINE_STATS
+  const auto t1 = Clock::now();
+  pending_decode_frame_.texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
+  const auto t_draw0 = t1;
 #endif
 
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -130,7 +129,7 @@ bool DecodeScene::redraw() {
   glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
 #ifdef STREAMING_PIPELINE_STATS
-  pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+  pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t_draw0);
   decode_stats_.record(pending_decode_frame_);
 #endif
 
@@ -142,6 +141,7 @@ void DecodeScene::init_streaming() {
   input_file_ = std::make_unique<std::ifstream>("file.h264", std::ios::in | std::ios::binary);
   decoder_->init(video_stream_info_);
   rgb_frame_ = decoder_->rgb_frame();
+  display_frame_ = std::make_shared<FrameData>(video_stream_info_.width * video_stream_info_.height * CHANNELS_NUM);
 }
 
 void DecodeScene::init_scene() {

--- a/streaming/streaming_encode_decode/decode_scene.hpp
+++ b/streaming/streaming_encode_decode/decode_scene.hpp
@@ -45,6 +45,7 @@ private:
   std::unique_ptr<Decoder> decoder_;
 
   std::shared_ptr<FrameData> rgb_frame_{};
+  std::shared_ptr<FrameData> display_frame_{};
   bool frame_ready_{};
 
   std::unique_ptr<gp::gl::VertexArrayObject> vao_{};

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -84,42 +84,23 @@ void DecodeScene::finalize() {
   frame_texture_.reset();
   vertex_buffer_.reset();
   vao_.reset();
+  display_frame_.reset();
   rgb_frame_.reset();
   decoder_.reset();
   decoder_ = std::make_unique<Decoder>();
 }
 
 void DecodeScene::decode() {
-  constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
-
-  if (frame_ready_) {
-    return;
-  }
-
   const auto status = decoder_->decode();
   switch (status.code) {
   case Decoder::Status::Code::OK: {
 #ifdef STREAMING_PIPELINE_STATS
-    using Clock = std::chrono::steady_clock;
-    const auto t0 = Clock::now();
-#endif
-    frame_texture_->bind();
-    frame_texture_->set_sub_image(0,
-                                  0,
-                                  0,
-                                  video_stream_info_.width,
-                                  video_stream_info_.height,
-                                  format,
-                                  GL_UNSIGNED_BYTE,
-                                  rgb_frame_->data());
-#ifdef STREAMING_PIPELINE_STATS
-    const auto t1 = Clock::now();
     const auto &dec_t = decoder_->last_timings();
     pending_decode_frame_ = {.upload_us = dec_t.upload_us,
                              .receive_us = dec_t.receive_us,
-                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us,
-                             .texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)};
+                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us};
 #endif
+    rgb_frame_->swap(*display_frame_);
     frame_ready_ = true;
     break;
   }
@@ -141,9 +122,27 @@ bool DecodeScene::redraw() {
     return false;
   }
 
+  constexpr auto format = CHANNELS_NUM == 4u ? GL_RGBA : GL_RGB;
+
 #ifdef STREAMING_PIPELINE_STATS
   using Clock = std::chrono::steady_clock;
   const auto t0 = Clock::now();
+#endif
+
+  frame_texture_->bind();
+  frame_texture_->set_sub_image(0,
+                                0,
+                                0,
+                                video_stream_info_.width,
+                                video_stream_info_.height,
+                                format,
+                                GL_UNSIGNED_BYTE,
+                                display_frame_->data());
+
+#ifdef STREAMING_PIPELINE_STATS
+  const auto t1 = Clock::now();
+  pending_decode_frame_.texture_upload_us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0);
+  const auto t_draw0 = t1;
 #endif
 
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -154,7 +153,7 @@ bool DecodeScene::redraw() {
   glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
 #ifdef STREAMING_PIPELINE_STATS
-  pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t0);
+  pending_decode_frame_.display_us = std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - t_draw0);
   if (decode_stats_.record(pending_decode_frame_)) {
     request_close();
   }
@@ -167,6 +166,7 @@ bool DecodeScene::redraw() {
 void DecodeScene::init_streaming() {
   decoder_->init(video_stream_info_);
   rgb_frame_ = decoder_->rgb_frame();
+  display_frame_ = std::make_shared<FrameData>(video_stream_info_.width * video_stream_info_.height * CHANNELS_NUM);
 }
 
 void DecodeScene::init_scene() {

--- a/streaming/streaming_receiver/decode_scene.hpp
+++ b/streaming/streaming_receiver/decode_scene.hpp
@@ -52,6 +52,7 @@ private:
   std::unique_ptr<Decoder> decoder_;
 
   std::shared_ptr<FrameData> rgb_frame_{};
+  std::shared_ptr<FrameData> display_frame_{};
   bool frame_ready_{};
 
   std::unique_ptr<gp::gl::VertexArrayObject> vao_{};

--- a/streaming/streaming_receiver/receiver.cpp
+++ b/streaming/streaming_receiver/receiver.cpp
@@ -271,6 +271,21 @@ void Receiver::on_data_channel_binary_message(rtc::binary message) {
   if (header.eof && incoming_video_stream_data_callback_) {
     incoming_video_stream_data_callback_(nullptr, 0, true);
   }
+
+  if (++ack_counter_ >= ACK_INTERVAL) {
+    ack_counter_ = 0;
+    std::shared_ptr<Peer> peer;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      peer = peer_;
+    }
+    if (peer && peer->data_channel && peer->data_channel->isOpen()) {
+      const auto json = nlohmann::json{
+          {"ack", {{"frame_num", header.frame_num}}}
+      };
+      peer->data_channel->send(json.dump());
+    }
+  }
 }
 
 void Receiver::on_data_channel_string_message(std::string /* message */) {

--- a/streaming/streaming_receiver/receiver.hpp
+++ b/streaming/streaming_receiver/receiver.hpp
@@ -74,6 +74,7 @@ private:
   const std::string receiver_id_{};
   const std::string id_{};
   std::atomic<bool> connection_open_{false};
+  std::size_t ack_counter_{0};
   rtc::Configuration configuration_{};
   std::string connection_url_;
   std::shared_ptr<rtc::WebSocket> web_socket_{};

--- a/streaming/streaming_streamer/encode_scene.cpp
+++ b/streaming/streaming_streamer/encode_scene.cpp
@@ -205,7 +205,17 @@ void EncodeScene::encode() {
 #endif
 
   if (mapped_ok) {
-    encoder_->encode();
+    const auto lag = frame_lag_.load();
+    int skip_interval = 1;
+    if (lag > LAG_THROTTLE_HEAVY) {
+      skip_interval = 4;
+    } else if (lag > LAG_THROTTLE_LIGHT) {
+      skip_interval = 2;
+    }
+    if (skip_counter_ == 0) {
+      encoder_->encode();
+    }
+    skip_counter_ = (skip_counter_ + 1) % skip_interval;
   }
 
 #ifdef STREAMING_PIPELINE_STATS

--- a/streaming/streaming_streamer/encode_scene.hpp
+++ b/streaming/streaming_streamer/encode_scene.hpp
@@ -35,6 +35,8 @@ public:
   void handle_event(const gp::misc::Event &event);
   void close();
 
+  void set_lag(std::uint64_t lag) noexcept { frame_lag_.store(lag); }
+
 #ifdef STREAMING_PIPELINE_STATS
   void set_stats_log(std::FILE *out) noexcept;
 #endif
@@ -78,6 +80,8 @@ private:
   std::mutex event_queue_mutex_{};
 
   std::atomic<bool> close_requested_{false};
+  std::atomic<std::uint64_t> frame_lag_{0};
+  int skip_counter_{0};
 
 #ifdef STREAMING_PIPELINE_STATS
   std::chrono::microseconds last_render_us_{};

--- a/streaming/streaming_streamer/main.cpp
+++ b/streaming/streaming_streamer/main.cpp
@@ -67,7 +67,7 @@ ProgramSetup process_args(const int argc, const char *const argv[]) {
           gp::ffmpeg::codec_name_to_id(vm["codec"].as<std::string>()),
           !vm.count("no-stun")
 #ifdef STREAMING_PIPELINE_STATS
-          ,
+              ,
           vm["stats-log"].as<std::string>()
 #endif
   };
@@ -100,6 +100,7 @@ int main(int argc, char *argv[]) {
 
   streamer->set_event_callback([&encode_scene](const gp::misc::Event &event) { encode_scene->handle_event(event); });
   streamer->set_close_callback([&encode_scene]() { encode_scene->close(); });
+  streamer->set_feedback_callback([&encode_scene](std::uint64_t lag) { encode_scene->set_lag(lag); });
   streamer->start(encode_scene->encoder());
 
   const auto result = encode_scene->exec();

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -161,10 +161,12 @@ void Streamer::on_data_channel_string_message(std::string message) {
     }
 
     if (json.contains("ack")) {
-      const auto acked_frame_num = json.at("ack").at("frame_num").template get<std::uint64_t>();
-      const auto current = frame_num_.load();
-      if (feedback_callback_ && current > acked_frame_num) {
-        feedback_callback_(current - acked_frame_num);
+      const auto acked_packet_num = json.at("ack").at("frame_num").template get<std::uint64_t>();
+      const auto next = frame_num_.load();
+      const auto last_sent = next > 0 ? next - 1 : 0;
+      const auto lag = acked_packet_num <= last_sent ? last_sent - acked_packet_num : 0;
+      if (feedback_callback_) {
+        feedback_callback_(lag);
       }
       return;
     }

--- a/streaming/streaming_streamer/streamer.cpp
+++ b/streaming/streaming_streamer/streamer.cpp
@@ -42,6 +42,10 @@ void Streamer::set_event_callback(std::function<void(const gp::misc::Event &even
 
 void Streamer::set_close_callback(std::function<void()> close_callback) { close_callback_ = std::move(close_callback); }
 
+void Streamer::set_feedback_callback(std::function<void(std::uint64_t lag)> feedback_callback) {
+  feedback_callback_ = std::move(feedback_callback);
+}
+
 void Streamer::init_web_socket(std::shared_ptr<rtc::WebSocket> web_socket) {
   auto weak_self = weak_from_this();
   web_socket->onOpen([weak_self]() {
@@ -153,6 +157,15 @@ void Streamer::on_data_channel_string_message(std::string message) {
 
     if (json.contains("event")) {
       parse_event(json.at("event"));
+      return;
+    }
+
+    if (json.contains("ack")) {
+      const auto acked_frame_num = json.at("ack").at("frame_num").template get<std::uint64_t>();
+      const auto current = frame_num_.load();
+      if (feedback_callback_ && current > acked_frame_num) {
+        feedback_callback_(current - acked_frame_num);
+      }
       return;
     }
 

--- a/streaming/streaming_streamer/streamer.hpp
+++ b/streaming/streaming_streamer/streamer.hpp
@@ -27,6 +27,7 @@ public:
   void start(std::shared_ptr<Encoder> encoder);
   void set_event_callback(std::function<void(const gp::misc::Event &event)> event_callback);
   void set_close_callback(std::function<void()> close_callback);
+  void set_feedback_callback(std::function<void(std::uint64_t lag)> feedback_callback);
 
 private:
   struct Peer {
@@ -61,12 +62,13 @@ private:
   std::string connection_url_{};
   VideoStreamInfo video_stream_info_{};
   std::atomic<bool> connection_open_{false};
-  std::uint64_t frame_num_{0};
+  std::atomic<std::uint64_t> frame_num_{0};
   rtc::Configuration configuration_{};
   std::shared_ptr<rtc::WebSocket> web_socket_{};
   std::shared_ptr<Peer> peer_{};
   mutable std::mutex mutex_{};
   std::function<void(const gp::misc::Event &event)> event_callback_{};
   std::function<void()> close_callback_{};
+  std::function<void(std::uint64_t lag)> feedback_callback_{};
 };
 } // namespace streaming


### PR DESCRIPTION
Closes #192

## Changes

### Task 1: Double-buffer decoded frames
Both `streaming_receiver/decode_scene` and `streaming_encode_decode/decode_scene` now use a second `display_frame_` buffer:
- Removed the `if (frame_ready_) return;` guard in `decode()` — the decoder now always consumes incoming packets, preventing the async buffer from backing up when rendering is rate-limited
- On a successful decode (`OK`): `rgb_frame_` and `display_frame_` are swapped (O(1) `std::vector::swap`); the decoder then immediately decodes the next packet on the next call
- Texture upload moved from `decode()` to `redraw()` — the GL upload now always uses the stable `display_frame_` while decoding runs freely

### Task 2: Receiver → Streamer bitrate feedback channel
- **Receiver** (`streaming_receiver/receiver`): sends `{"ack":{"frame_num":N}}` JSON string over the existing DataChannel every `ACK_INTERVAL` (10) received binary messages
- **Streamer** (`streaming_streamer/streamer`): parses incoming ACK, computes `lag = current_frame_num - acked_frame_num`, invokes a `feedback_callback`; `frame_num_` is now `std::atomic<uint64_t>` since it is written from the encoder callback thread and read from the WebRTC message handler thread
- **EncodeScene** (`streaming_streamer/encode_scene`): exposes `set_lag()` which stores lag into an atomic; `encode()` skips encoding based on thresholds — every 2nd frame above `LAG_THROTTLE_LIGHT` (10), every 4th above `LAG_THROTTLE_HEAVY` (30)
- **main.cpp**: wires the callback `streamer->set_feedback_callback([&encode_scene](uint64_t lag){ encode_scene->set_lag(lag); })`

### New constants (`streaming_common/constants.hpp`)
```cpp
constexpr auto ACK_INTERVAL       = std::size_t{10};
constexpr auto LAG_THROTTLE_LIGHT = std::uint64_t{10};
constexpr auto LAG_THROTTLE_HEAVY = std::uint64_t{30};
```