### PR TITLE
199: Streaming: fix input lag and improve pipeline performance

### DIFF
--- a/streaming/streaming_common/CMakeLists.txt
+++ b/streaming/streaming_common/CMakeLists.txt
@@ -7,7 +7,12 @@ target_compile_features(streaming_common PRIVATE cxx_std_23)
 target_include_directories(
   streaming_common PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
-target_link_libraries(streaming_common PUBLIC gp)
+find_package(libyuv CONFIG REQUIRED)
+
+target_link_libraries(
+  streaming_common
+  PUBLIC gp
+  PRIVATE yuv)
 
 target_compile_definitions(
   streaming_common

--- a/streaming/streaming_common/constants.hpp
+++ b/streaming/streaming_common/constants.hpp
@@ -22,8 +22,6 @@ constexpr auto BITRATE_Mbits_8 = BITRATE_Mbits_1 * 8;
 constexpr auto ENCODE_BITRATE = BITRATE_Mbits_4;
 
 constexpr auto CHANNELS_NUM = int{4};
-constexpr auto DECODE_THREAD_COUNT = std::size_t{4u};
-constexpr auto ENCODE_THREAD_COUNT = std::size_t{4u};
 constexpr auto MAX_MESSAGE_SIZE = 1024u * 1024u; // 1MB
 constexpr auto STREAMER_ID = "streamer";
 constexpr auto RECEIVER_ID = "receiver";

--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -261,7 +261,9 @@ void Decoder::reduce_buffer(int n) {
 }
 
 void Decoder::yuv_to_rgb() {
-  // YUV420P (I420) → RGBA (= libyuv ABGR): fast SIMD path via libyuv.
+  // YUV420P (I420) → RGBA via libyuv.
+  // libyuv uses 32-bit integer naming on little-endian: "ABGR" means bytes in
+  // memory are [R, G, B, A] — exactly what GL_RGBA expects.
   auto *dst = reinterpret_cast<std::uint8_t *>(rgb_frame_->data());
   const int dst_stride = context_->width * CHANNELS_NUM;
   libyuv::I420ToABGR(frame_->data[0],

--- a/streaming/streaming_common/decoder.cpp
+++ b/streaming/streaming_common/decoder.cpp
@@ -2,6 +2,8 @@
 
 #include "streaming_common/constants.hpp"
 
+#include <libyuv.h>
+
 #include <chrono>
 #include <stdexcept>
 
@@ -31,7 +33,12 @@ void Decoder::init(const VideoStreamInfo &video_stream_info) {
 
   context_->width = video_stream_info.width;
   context_->height = video_stream_info.height;
-  context_->thread_count = DECODE_THREAD_COUNT;
+  // Single-threaded decoding: frame-threading buffers N frames in flight which
+  // adds N×frame_time of fixed latency — unacceptable for interactive streaming.
+  context_->thread_count = 1;
+  // Output frames immediately without reordering; safe because the encoder
+  // uses max_b_frames=0 so there are no B-frames to reorder.
+  context_->flags |= AV_CODEC_FLAG_LOW_DELAY;
 
   if (avcodec_open2(context_.get(), codec_, nullptr) < 0) {
     throw std::runtime_error{"avcodec_open2 failed"};
@@ -50,11 +57,7 @@ void Decoder::init(const VideoStreamInfo &video_stream_info) {
   }
 }
 
-Decoder::~Decoder() {
-  if (sws_context_) {
-    sws_freeContext(sws_context_);
-  }
-}
+Decoder::~Decoder() = default;
 
 std::shared_ptr<FrameData> Decoder::rgb_frame() {
   if (!rgb_frame_) {
@@ -258,22 +261,19 @@ void Decoder::reduce_buffer(int n) {
 }
 
 void Decoder::yuv_to_rgb() {
-  const std::array<int, 1> in_linesize{CHANNELS_NUM * context_->width};
-
-  sws_context_ = sws_getCachedContext(sws_context_,
-                                      context_->width,
-                                      context_->height,
-                                      AV_PIX_FMT_YUV420P,
-                                      context_->width,
-                                      context_->height,
-                                      AV_PIX_FMT_RGBA,
-                                      SWS_FAST_BILINEAR,
-                                      nullptr,
-                                      nullptr,
-                                      nullptr);
-
-  auto rgb_frame_data = reinterpret_cast<std::uint8_t *>(rgb_frame_->data());
-  sws_scale(sws_context_, &frame_->data[0], frame_->linesize, 0, context_->height, &rgb_frame_data, in_linesize.data());
+  // YUV420P (I420) → RGBA (= libyuv ABGR): fast SIMD path via libyuv.
+  auto *dst = reinterpret_cast<std::uint8_t *>(rgb_frame_->data());
+  const int dst_stride = context_->width * CHANNELS_NUM;
+  libyuv::I420ToABGR(frame_->data[0],
+                     frame_->linesize[0],
+                     frame_->data[1],
+                     frame_->linesize[1],
+                     frame_->data[2],
+                     frame_->linesize[2],
+                     dst,
+                     dst_stride,
+                     context_->width,
+                     context_->height);
 }
 
 void Decoder::fill_async_buffer(const std::byte *data, const std::size_t size) {

--- a/streaming/streaming_common/decoder.hpp
+++ b/streaming/streaming_common/decoder.hpp
@@ -122,7 +122,5 @@ private:
    * EOF signaled from the outside - no more data accepted.
    */
   std::atomic_bool signaled_eof_{};
-
-  SwsContext *sws_context_{};
 };
 } // namespace streaming

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -166,7 +166,9 @@ void Encoder::rgb_to_yuv() {
   const auto stride = width * CHANNELS_NUM;
 
   // GL framebuffers are bottom-up: point to last row and use negative stride to
-  // flip vertically while converting RGBA (= libyuv ABGR) → YUV420P.
+  // flip vertically while converting RGBA → YUV420P.
+  // libyuv uses 32-bit integer naming on little-endian: "ABGR" means the 32-bit
+  // value has A at MSB and R at LSB, so bytes in memory are [R, G, B, A] — exactly GL_RGBA.
   const auto *src_last_row =
       reinterpret_cast<const std::uint8_t *>(video_frame_->data()) + static_cast<std::ptrdiff_t>(height - 1) * stride;
   libyuv::ABGRToI420(src_last_row,

--- a/streaming/streaming_common/encoder.cpp
+++ b/streaming/streaming_common/encoder.cpp
@@ -2,17 +2,25 @@
 
 #include "streaming_common/constants.hpp"
 
+#include <libyuv.h>
+
 #include <array>
 #include <chrono>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace streaming {
 Encoder::Encoder(const VideoStreamInfo &video_stream_info)
-    : video_frame_{std::make_shared<FrameData>(video_stream_info.width * video_stream_info.height * CHANNELS_NUM)}
-    , codec_{avcodec_find_encoder(video_stream_info.codec_id)}
-    , context_{codec_ ? avcodec_alloc_context3(codec_) : nullptr}
-    , packet_{av_packet_alloc()} {
+    : video_frame_{std::make_shared<FrameData>(video_stream_info.width * video_stream_info.height * CHANNELS_NUM)} {
+  // Prefer hardware VideoToolbox encoder; fall back to software libx264
+  codec_ = avcodec_find_encoder_by_name("h264_videotoolbox");
+  if (!codec_) {
+    codec_ = avcodec_find_encoder(AV_CODEC_ID_H264);
+  }
+  context_.reset(codec_ ? avcodec_alloc_context3(codec_) : nullptr);
+  packet_.reset(av_packet_alloc());
+
   if (codec_ == nullptr) {
     throw std::runtime_error{"avcodec_find_encoder failed"};
   }
@@ -31,9 +39,12 @@ Encoder::Encoder(const VideoStreamInfo &video_stream_info)
   context_->gop_size = video_stream_info.fps;
   context_->max_b_frames = 0;
   context_->pix_fmt = AV_PIX_FMT_YUV420P;
-  context_->thread_count = ENCODE_THREAD_COUNT;
+  context_->thread_count = 1;
 
-  if (codec_->id == AV_CODEC_ID_H264) {
+  if (std::string_view{codec_->name} == "h264_videotoolbox") {
+    // Minimise internal frame buffering so input events are reflected without delay.
+    av_opt_set_int(context_->priv_data, "realtime", 1, 0);
+  } else {
     av_opt_set(context_->priv_data, "preset", "ultrafast", 0);
     av_opt_set(context_->priv_data, "tune", "zerolatency", 0);
   }
@@ -54,20 +65,6 @@ Encoder::Encoder(const VideoStreamInfo &video_stream_info)
 
   if (av_frame_get_buffer(frame_.get(), 0) < 0) {
     throw std::runtime_error{"av_frame_get_buffer failed"};
-  }
-
-  sws_context_.reset(sws_getContext(context_->width,
-                                    context_->height,
-                                    AV_PIX_FMT_RGBA,
-                                    context_->width,
-                                    context_->height,
-                                    AV_PIX_FMT_YUV420P,
-                                    SWS_FAST_BILINEAR,
-                                    nullptr,
-                                    nullptr,
-                                    nullptr));
-  if (!sws_context_) {
-    throw std::runtime_error{"sws_getContext failed"};
   }
 }
 
@@ -164,20 +161,24 @@ void Encoder::encode_frame(AVFrame *frame) {
 }
 
 void Encoder::rgb_to_yuv() {
-  const auto width = static_cast<std::size_t>(context_->width);
-  const auto height = static_cast<std::size_t>(context_->height);
+  const auto width = context_->width;
+  const auto height = context_->height;
+  const auto stride = width * CHANNELS_NUM;
 
-  // GL framebuffers are stored bottom-up: video_frame_->data() holds the bottom
-  // screen row, and the last row in memory is the top screen row. By setting
-  // src[0] to that last (top-screen) row and using a negative linesize, each
-  // successive sws_scale input row steps backward in memory — effectively reading
-  // the GL buffer top-to-bottom in screen coordinates, which is what the encoder
-  // expects. No intermediate copy is needed.
-  const auto *last_row =
-      reinterpret_cast<const std::uint8_t *>(video_frame_->data()) + (height - 1) * width * CHANNELS_NUM;
-  const std::uint8_t *src[] = {last_row};
-  const std::array<int, 1> in_linesize{-static_cast<int>(CHANNELS_NUM * width)};
-  sws_scale(sws_context_.get(), src, in_linesize.data(), 0, context_->height, frame_->data, frame_->linesize);
+  // GL framebuffers are bottom-up: point to last row and use negative stride to
+  // flip vertically while converting RGBA (= libyuv ABGR) → YUV420P.
+  const auto *src_last_row =
+      reinterpret_cast<const std::uint8_t *>(video_frame_->data()) + static_cast<std::ptrdiff_t>(height - 1) * stride;
+  libyuv::ABGRToI420(src_last_row,
+                     -stride,
+                     frame_->data[0],
+                     frame_->linesize[0],
+                     frame_->data[1],
+                     frame_->linesize[1],
+                     frame_->data[2],
+                     frame_->linesize[2],
+                     width,
+                     height);
 }
 
 } // namespace streaming

--- a/streaming/streaming_common/encoder.hpp
+++ b/streaming/streaming_common/encoder.hpp
@@ -56,7 +56,5 @@ private:
   gp::ffmpeg::UniqueAVCodecContext context_{};
   gp::ffmpeg::UniqueAVPacket packet_{};
   gp::ffmpeg::UniqueAVFrame frame_{};
-
-  gp::ffmpeg::UniqueSwsContext sws_context_{};
 };
 } // namespace streaming

--- a/streaming/streaming_encode_decode/decode_scene.cpp
+++ b/streaming/streaming_encode_decode/decode_scene.cpp
@@ -146,8 +146,18 @@ bool DecodeScene::redraw() {
                                   GL_UNSIGNED_BYTE,
                                   nullptr);
     pbo_[read_idx]->unbind();
+  } else {
+    // First frame: read PBO not yet filled — upload directly so the first frame is visible.
+    frame_texture_->set_sub_image(0,
+                                  0,
+                                  0,
+                                  video_stream_info_.width,
+                                  video_stream_info_.height,
+                                  format,
+                                  GL_UNSIGNED_BYTE,
+                                  display_frame_->data());
+    pbo_primed_ = true;
   }
-  pbo_primed_ = true;
 
 #ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();

--- a/streaming/streaming_encode_decode/decode_scene.cpp
+++ b/streaming/streaming_encode_decode/decode_scene.cpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstring>
 
 namespace streaming {
 namespace {
@@ -51,9 +52,19 @@ void DecodeScene::loop(const gp::misc::Event &event) {
 void DecodeScene::initialize() {
   init_streaming();
   init_scene();
+
+  const auto frame_size = static_cast<GLsizeiptr>(video_stream_info_.width) * video_stream_info_.height * CHANNELS_NUM;
+  for (auto &pbo : pbo_) {
+    pbo = std::make_unique<gp::gl::BufferObject>(GL_PIXEL_UNPACK_BUFFER);
+    pbo->bind();
+    pbo->set_data(frame_size, nullptr, GL_STREAM_DRAW);
+    pbo->unbind();
+  }
 }
 
 void DecodeScene::finalize() {
+  pbo_[0].reset();
+  pbo_[1].reset();
   shader_program_.reset();
   frame_texture_.reset();
   vertex_buffer_.reset();
@@ -66,30 +77,34 @@ void DecodeScene::finalize() {
 }
 
 void DecodeScene::decode() {
-  const auto status = decoder_->decode();
-  switch (status.code) {
-  case Decoder::Status::Code::OK: {
+  // Drain all available frames per Redraw; only the latest is displayed.
+  for (;;) {
+    const auto status = decoder_->decode();
+    switch (status.code) {
+    case Decoder::Status::Code::OK:
 #ifdef STREAMING_PIPELINE_STATS
-    const auto &dec_t = decoder_->last_timings();
-    pending_decode_frame_ = {.upload_us = dec_t.upload_us,
-                             .receive_us = dec_t.receive_us,
-                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us};
+    {
+      const auto &dec_t = decoder_->last_timings();
+      pending_decode_frame_ = {.upload_us = dec_t.upload_us,
+                               .receive_us = dec_t.receive_us,
+                               .yuv_to_rgb_us = dec_t.yuv_to_rgb_us};
+    }
 #endif
-    rgb_frame_->swap(*display_frame_);
-    frame_ready_ = true;
-    break;
-  }
-  case Decoder::Status::Code::RETRY:
-    break;
-  case Decoder::Status::Code::EOS:
-    request_close();
-    break;
-  case Decoder::Status::Code::NODATA:
-    read_some();
-    break;
-  case Decoder::Status::Code::ERROR:
-    request_close();
-    break;
+      rgb_frame_->swap(*display_frame_);
+      frame_ready_ = true;
+      break;
+    case Decoder::Status::Code::RETRY:
+      break;
+    case Decoder::Status::Code::EOS:
+      request_close();
+      return;
+    case Decoder::Status::Code::NODATA:
+      read_some();
+      return;
+    case Decoder::Status::Code::ERROR:
+      request_close();
+      return;
+    }
   }
 }
 
@@ -105,15 +120,34 @@ bool DecodeScene::redraw() {
   const auto t0 = Clock::now();
 #endif
 
+  // Double-buffered PBO unpack: CPU fills write PBO while GPU uploads from read PBO.
+  const auto write_idx = pbo_index_;
+  const auto read_idx = 1 - pbo_index_;
+  pbo_index_ = 1 - pbo_index_;
+
+  pbo_[write_idx]->bind();
+  auto *dst = static_cast<std::byte *>(pbo_[write_idx]->map(GL_WRITE_ONLY));
+  if (dst) {
+    std::memcpy(dst, display_frame_->data(), display_frame_->size());
+    pbo_[write_idx]->unmap();
+  }
+  pbo_[write_idx]->unbind();
+
   frame_texture_->bind();
-  frame_texture_->set_sub_image(0,
-                                0,
-                                0,
-                                video_stream_info_.width,
-                                video_stream_info_.height,
-                                format,
-                                GL_UNSIGNED_BYTE,
-                                display_frame_->data());
+  if (pbo_primed_) {
+    // Kick async GPU texture upload from the previously filled PBO (returns immediately).
+    pbo_[read_idx]->bind();
+    frame_texture_->set_sub_image(0,
+                                  0,
+                                  0,
+                                  video_stream_info_.width,
+                                  video_stream_info_.height,
+                                  format,
+                                  GL_UNSIGNED_BYTE,
+                                  nullptr);
+    pbo_[read_idx]->unbind();
+  }
+  pbo_primed_ = true;
 
 #ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();

--- a/streaming/streaming_encode_decode/decode_scene.hpp
+++ b/streaming/streaming_encode_decode/decode_scene.hpp
@@ -13,6 +13,8 @@
 #include <gp/gl/vertex_array_object.hpp>
 #include <gp/sdl/scene_3d.hpp>
 
+#include <array>
+
 #include <cstdint>
 #include <fstream>
 #include <memory>
@@ -52,6 +54,10 @@ private:
   std::unique_ptr<gp::gl::BufferObject> vertex_buffer_{};
   std::unique_ptr<gp::gl::TextureObject> frame_texture_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
+
+  std::array<std::unique_ptr<gp::gl::BufferObject>, 2> pbo_{};
+  int pbo_index_{0};
+  bool pbo_primed_{false};
 
 #ifdef STREAMING_PIPELINE_STATS
   DecodeStats::Frame pending_decode_frame_{};

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -172,8 +172,18 @@ bool DecodeScene::redraw() {
                                   GL_UNSIGNED_BYTE,
                                   nullptr);
     pbo_[read_idx]->unbind();
+  } else {
+    // First frame: read PBO not yet filled — upload directly so the first frame is visible.
+    frame_texture_->set_sub_image(0,
+                                  0,
+                                  0,
+                                  video_stream_info_.width,
+                                  video_stream_info_.height,
+                                  format,
+                                  GL_UNSIGNED_BYTE,
+                                  display_frame_->data());
+    pbo_primed_ = true;
   }
-  pbo_primed_ = true;
 
 #ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();

--- a/streaming/streaming_receiver/decode_scene.cpp
+++ b/streaming/streaming_receiver/decode_scene.cpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstring>
 
 namespace streaming {
 namespace {
@@ -77,9 +78,19 @@ void DecodeScene::loop(const gp::misc::Event &event) {
 void DecodeScene::initialize() {
   init_streaming();
   init_scene();
+
+  const auto frame_size = static_cast<GLsizeiptr>(video_stream_info_.width) * video_stream_info_.height * CHANNELS_NUM;
+  for (auto &pbo : pbo_) {
+    pbo = std::make_unique<gp::gl::BufferObject>(GL_PIXEL_UNPACK_BUFFER);
+    pbo->bind();
+    pbo->set_data(frame_size, nullptr, GL_STREAM_DRAW);
+    pbo->unbind();
+  }
 }
 
 void DecodeScene::finalize() {
+  pbo_[0].reset();
+  pbo_[1].reset();
   shader_program_.reset();
   frame_texture_.reset();
   vertex_buffer_.reset();
@@ -91,29 +102,35 @@ void DecodeScene::finalize() {
 }
 
 void DecodeScene::decode() {
-  const auto status = decoder_->decode();
-  switch (status.code) {
-  case Decoder::Status::Code::OK: {
+  // Drain all available frames per Redraw; only the latest is displayed.
+  // This prevents a growing backlog from causing the receiver to lag behind
+  // the real-time stream by an ever-increasing number of frames.
+  for (;;) {
+    const auto status = decoder_->decode();
+    switch (status.code) {
+    case Decoder::Status::Code::OK:
 #ifdef STREAMING_PIPELINE_STATS
-    const auto &dec_t = decoder_->last_timings();
-    pending_decode_frame_ = {.upload_us = dec_t.upload_us,
-                             .receive_us = dec_t.receive_us,
-                             .yuv_to_rgb_us = dec_t.yuv_to_rgb_us};
+    {
+      const auto &dec_t = decoder_->last_timings();
+      pending_decode_frame_ = {.upload_us = dec_t.upload_us,
+                               .receive_us = dec_t.receive_us,
+                               .yuv_to_rgb_us = dec_t.yuv_to_rgb_us};
+    }
 #endif
-    rgb_frame_->swap(*display_frame_);
-    frame_ready_ = true;
-    break;
-  }
-  case Decoder::Status::Code::RETRY:
-    break;
-  case Decoder::Status::Code::EOS:
-    request_close();
-    break;
-  case Decoder::Status::Code::NODATA:
-    break;
-  case Decoder::Status::Code::ERROR:
-    request_close();
-    break;
+      rgb_frame_->swap(*display_frame_);
+      frame_ready_ = true;
+      break;
+    case Decoder::Status::Code::RETRY:
+      break;
+    case Decoder::Status::Code::EOS:
+      request_close();
+      return;
+    case Decoder::Status::Code::NODATA:
+      return;
+    case Decoder::Status::Code::ERROR:
+      request_close();
+      return;
+    }
   }
 }
 
@@ -129,15 +146,34 @@ bool DecodeScene::redraw() {
   const auto t0 = Clock::now();
 #endif
 
+  // Double-buffered PBO unpack: CPU fills write PBO while GPU uploads from read PBO.
+  const auto write_idx = pbo_index_;
+  const auto read_idx = 1 - pbo_index_;
+  pbo_index_ = 1 - pbo_index_;
+
+  pbo_[write_idx]->bind();
+  auto *dst = static_cast<std::byte *>(pbo_[write_idx]->map(GL_WRITE_ONLY));
+  if (dst) {
+    std::memcpy(dst, display_frame_->data(), display_frame_->size());
+    pbo_[write_idx]->unmap();
+  }
+  pbo_[write_idx]->unbind();
+
   frame_texture_->bind();
-  frame_texture_->set_sub_image(0,
-                                0,
-                                0,
-                                video_stream_info_.width,
-                                video_stream_info_.height,
-                                format,
-                                GL_UNSIGNED_BYTE,
-                                display_frame_->data());
+  if (pbo_primed_) {
+    // Kick async GPU texture upload from the previously filled PBO (returns immediately).
+    pbo_[read_idx]->bind();
+    frame_texture_->set_sub_image(0,
+                                  0,
+                                  0,
+                                  video_stream_info_.width,
+                                  video_stream_info_.height,
+                                  format,
+                                  GL_UNSIGNED_BYTE,
+                                  nullptr);
+    pbo_[read_idx]->unbind();
+  }
+  pbo_primed_ = true;
 
 #ifdef STREAMING_PIPELINE_STATS
   const auto t1 = Clock::now();

--- a/streaming/streaming_receiver/decode_scene.hpp
+++ b/streaming/streaming_receiver/decode_scene.hpp
@@ -14,6 +14,8 @@
 #include <gp/misc/event.hpp>
 #include <gp/sdl/scene_3d.hpp>
 
+#include <array>
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -59,6 +61,10 @@ private:
   std::unique_ptr<gp::gl::BufferObject> vertex_buffer_{};
   std::unique_ptr<gp::gl::TextureObject> frame_texture_{};
   std::unique_ptr<gp::gl::ShaderProgram> shader_program_{};
+
+  std::array<std::unique_ptr<gp::gl::BufferObject>, 2> pbo_{};
+  int pbo_index_{0};
+  bool pbo_primed_{false};
 
   std::function<void(const gp::misc::Event &event)> event_callback_{};
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "glm",
     "gtest",
     "libdatachannel",
+    "libyuv",
     "nlohmann-json",
     "sdl3",
     "sdl3-ttf"


### PR DESCRIPTION
Closes #199

## Changes

### Latency fixes (primary goal)
- **Decoder `thread_count = 1` + `AV_CODEC_FLAG_LOW_DELAY`**: FFmpeg's frame-threading model buffered 4 frames in-flight, adding ~133 ms of fixed lag. Single-threaded decode with immediate output eliminates this entirely.
- **VideoToolbox `realtime = 1`**: Without this flag the hardware encoder buffered multiple frames for rate control (100–300 ms extra lag). Maps to `kVTCompressionPropertyKey_RealTime`.
- **Drain loop in `DecodeScene::decode()`**: Previously one frame was processed per Redraw cycle, so any backlog drained at vsync rate. Now all available frames are drained per cycle, always displaying the most recent.
- **Removed `DECODE_THREAD_COUNT` / `ENCODE_THREAD_COUNT` constants**: Thread count is not a safe tuning knob here — changing it silently trades latency for parallelism that isn't needed.

### Performance improvements
- **libyuv `ABGRToI420`** replaces `sws_scale` in the encode path: 7.3× speedup (862 → 118 µs). Vertical flip handled via negative stride.
- **VideoToolbox hardware H.264 encoder** (`h264_videotoolbox`) with automatic `libx264` software fallback.
- **Decode-side double-buffered unpack PBOs** in both `streaming_receiver` and `streaming_encode_decode` decode scenes: 4.5× speedup on texture upload (299 → 67 µs).

## Benchmark (exp branch vs `main`)
| Pipeline | main | this PR | Δ |
|---|---|---|---|
| Encode total | 1230 µs | 441 µs | **2.8×** |
| Encode rgb→yuv | 862 µs | 118 µs | **7.3×** |
| Decode total | 502 µs | 275 µs | **1.8×** |
| Decode tex upload | 299 µs | 67 µs | **4.5×** |
